### PR TITLE
UI: Fix issue #21: Resizing of vogleditor window is slow depending on trace size

### DIFF
--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -101,7 +101,7 @@ private:
    QPixmap* m_pPixmap;
 
    void drawBaseTimeline(QPainter* painter, const QRect& rect, int gap);
-   void drawTimelineItem(QPainter* painter, vogleditor_timelineItem* pItem, int height);
+   void drawTimelineItem(QPainter* painter, vogleditor_timelineItem* pItem, int height, float &minimumOffset);
 
    float scaleDurationHorizontally(float value);
    float scalePositionHorizontally(float value);

--- a/src/vogleditor/vogleditor_timelineitem.cpp
+++ b/src/vogleditor/vogleditor_timelineitem.cpp
@@ -52,13 +52,19 @@ vogleditor_timelineItem::vogleditor_timelineItem(float begin, float end, vogledi
 
 vogleditor_timelineItem::~vogleditor_timelineItem()
 {
+    for (int i = 0; i < m_childItems.size(); i++)
+    {
+        delete m_childItems[i];
+        m_childItems[i] = NULL;
+    }
+    m_childItems.clear();
 }
 
 void vogleditor_timelineItem::appendChild(vogleditor_timelineItem* child)
 {
-    childItems.append(child);
+    m_childItems.append(child);
 
-    if (childItems.size() == 1)
+    if (m_childItems.size() == 1)
     {
         // just added the first child, so overwrite the current maxChildDuration
         m_maxChildDuration = child->getMaxChildDuration();
@@ -72,12 +78,12 @@ void vogleditor_timelineItem::appendChild(vogleditor_timelineItem* child)
 
 vogleditor_timelineItem* vogleditor_timelineItem::child(int row)
 {
-   return childItems[row];
+   return m_childItems[row];
 }
 
 int vogleditor_timelineItem::childCount() const
 {
-   return childItems.size();
+   return m_childItems.size();
 }
 
 vogleditor_timelineItem* vogleditor_timelineItem::parent()

--- a/src/vogleditor/vogleditor_timelineitem.h
+++ b/src/vogleditor/vogleditor_timelineitem.h
@@ -88,7 +88,7 @@ private:
     bool m_isSpan;
     float m_maxChildDuration;
 
-    QList<vogleditor_timelineItem*> childItems;
+    QList<vogleditor_timelineItem*> m_childItems;
 
     vogleditor_timelineItem* m_parentItem;
     vogleditor_frameItem* m_pFrameItem;


### PR DESCRIPTION
- If the window is only being resized a small amount (within 20%), the timeline will no longer redraw and simply gets stretched.
- When the timeline is redrawn, it will now only draw one timeline item per pixel instead of many sub-pixel items.
- Fixed an issue that caused 0-duration items from being scaled to 1 instead of the horizontal scale value (which should be the minimum amount of time needed to appear as a single pixel). This greatly reduced the number of items being drawn.
- Fixed deletion of timeline item children.
- These improvements reduced the number of drawn items in one particular trace file from ~5.9 million, down to ~1250 in the default window size. When I stretched the editor across two monitors (giving the timeline more pixels to draw into) this increased to ~4500 items - both very reasonable numbers.

This code will likely need to be revisited in the future once we actually utilize the timeline items having children, when we add more hierarchy to the API call tree, using: string markers, glBegin/glEnd, display list construction, etc
