### PR TITLE
UI: Fix a bunch of memory leaks; rename a few member variables

### DIFF
--- a/src/vogleditor/vogleditor.h
+++ b/src/vogleditor/vogleditor.h
@@ -67,6 +67,7 @@ class vogleditor_apiCallTimelineModel;
 class vogleditor_apiCallTreeItem;
 class vogleditor_gl_state_snapshot;
 class vogleditor_QApiCallTreeModel;
+class vogleditor_QStateTreeModel;
 
 class VoglEditor : public QMainWindow
 {
@@ -144,13 +145,19 @@ private:
    bool save_snapshot_to_disk(vogl_gl_state_snapshot* pSnapshot, dynamic_string filename, vogl_blob_manager *pBlob_manager);
 
    QString m_openFilename;
-   QLabel* m_statusLabel;
-   vogleditor_QFramebufferExplorer* m_framebufferExplorer;
-   vogleditor_QTextureExplorer* m_textureExplorer;
-   vogleditor_QTextureExplorer* m_renderbufferExplorer;
-   vogleditor_QProgramExplorer* m_programExplorer;
-   vogleditor_QShaderExplorer* m_shaderExplorer;
+   QLabel* m_pStatusLabel;
+   vogleditor_QFramebufferExplorer* m_pFramebufferExplorer;
+   vogleditor_QTextureExplorer* m_pTextureExplorer;
+   vogleditor_QTextureExplorer* m_pRenderbufferExplorer;
+   vogleditor_QProgramExplorer* m_pProgramExplorer;
+   vogleditor_QShaderExplorer* m_pShaderExplorer;
    vogleditor_QTimelineView* m_timeline;
+
+   QGridLayout* m_pFramebufferTab_layout;
+   QGridLayout* m_pTextureTab_layout;
+   QGridLayout* m_pRenderbufferTab_layout;
+   QGridLayout* m_pProgramTab_layout;
+   QGridLayout* m_pShaderTab_layout;
 
    vogleditor_gl_state_snapshot* m_currentSnapshot;
    vogleditor_apiCallTreeItem* m_pCurrentCallTreeItem;
@@ -166,8 +173,9 @@ private:
    vogl::hash_map<vogl::uint32, vogl::json_node*> m_backtraceToJsonMap;
 
    vogleditor_apiCallTimelineModel* m_pTimelineModel;
+   vogleditor_QApiCallTreeModel* m_pApiCallTreeModel;
+   vogleditor_QStateTreeModel* m_pStateTreeModel;
 
-   vogleditor_QApiCallTreeModel* m_pApicallTreeModel;
    QColor m_searchTextboxBackgroundColor;
 };
 

--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -99,19 +99,19 @@ vogleditor_apiCallTreeItem::~vogleditor_apiCallTreeItem()
 {
    if (m_pFrameItem != NULL)
    {
-      delete m_pFrameItem;
+      vogl_delete(m_pFrameItem);
       m_pFrameItem = NULL;
    }
 
    if (m_pApiCallItem != NULL)
    {
-      delete m_pApiCallItem;
+      vogl_delete(m_pApiCallItem);
       m_pApiCallItem = NULL;
    }
 
    for (int i = 0; i < m_childItems.size(); i++)
    {
-      delete m_childItems[i];
+      vogl_delete(m_childItems[i]);
       m_childItems[i] = NULL;
    }
 

--- a/src/vogleditor/vogleditor_frameitem.h
+++ b/src/vogleditor/vogleditor_frameitem.h
@@ -45,11 +45,6 @@ public:
 
    ~vogleditor_frameItem()
    {
-      for (int i = 0; i < m_apiCallList.size(); i++)
-      {
-         vogl_delete(m_apiCallList[i]);
-         m_apiCallList[i] = NULL;
-      }
       m_apiCallList.clear();
    }
 

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -34,7 +34,7 @@
 vogleditor_QApiCallTreeModel::vogleditor_QApiCallTreeModel(vogl_trace_file_reader* reader, QObject *parent)
     : QAbstractItemModel(parent)
 {
-    m_rootItem = new vogleditor_apiCallTreeItem(this);
+    m_rootItem = vogl_new(vogleditor_apiCallTreeItem, this);
     setupModelData(reader, m_rootItem);
 }
 
@@ -42,7 +42,7 @@ vogleditor_QApiCallTreeModel::~vogleditor_QApiCallTreeModel()
 {
    if (m_rootItem != NULL)
    {
-      delete m_rootItem;
+      vogl_delete(m_rootItem);
       m_rootItem = NULL;
    }
 
@@ -196,7 +196,7 @@ void vogleditor_QApiCallTreeModel::setupModelData(vogl_trace_file_reader* pTrace
          // and append it to the parent
          if (pCurFrame == NULL)
          {
-            pCurFrame = new vogleditor_frameItem(total_swaps);
+            pCurFrame = vogl_new(vogleditor_frameItem, total_swaps);
             vogleditor_apiCallTreeItem* pNewFrameNode = vogl_new(vogleditor_apiCallTreeItem, pCurFrame, pCurParent);
             pCurParent->appendChild(pNewFrameNode);
             m_itemList.append(pNewFrameNode);


### PR DESCRIPTION
- A bunch of UI elements were not being deleted in VoglEditor.
- The ApiCallTreeModel (which maintains all the API calls and snapshopts) was being allocated each time a trace was opened, but never deleted when the trace was closed.
- The StateTreeModel was being reallocated each time the UI was updated to a new snapshot, but they were never being deleted.
- ApiCallItems were being deleted by BOTH the FrameItem and the ApiCallTreeItem; they are now only deleted by the ApiCallTreeItem.
