### PR TITLE
Fixing issue #32.

### DIFF
--- a/src/gltests/core-vao/main.c
+++ b/src/gltests/core-vao/main.c
@@ -49,9 +49,7 @@ int main( /* int argc , char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint level5Pixels[] = { 0xFF00FFFF, 0xFF00FF00, 0xFFFF0000, 0xFF000000 };

--- a/src/gltests/fixedfunc-multitexcoord-2d/main.c
+++ b/src/gltests/fixedfunc-multitexcoord-2d/main.c
@@ -48,9 +48,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint pixels[] = { 0xFF00FFFF, 0xFF00FF00, 0xFFFF0000, 0xFF000000 };

--- a/src/gltests/include/testcommon.h
+++ b/src/gltests/include/testcommon.h
@@ -6,9 +6,7 @@
 #include <SDL2/SDL.h>
 #include <stdbool.h>
 
-#ifndef NDEBUG
 #include <assert.h>
-#endif
 
 void CompileShader(GLuint shader, char* shaderName)
 {

--- a/src/gltests/msaa_depthstencil/main.c
+++ b/src/gltests/msaa_depthstencil/main.c
@@ -49,9 +49,7 @@ int main( int argc , char* args[] )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint level5Pixels[] = { 0xFF00FFFF, 0xFF00FF00, 0xFFFF0000, 0xFF000000 };

--- a/src/gltests/texture-array-1d/main.c
+++ b/src/gltests/texture-array-1d/main.c
@@ -49,9 +49,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint texAllPixels[] = { 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 

--- a/src/gltests/texture-array-2d-msaa/main.c
+++ b/src/gltests/texture-array-2d-msaa/main.c
@@ -49,9 +49,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint texAllPixels[] = { 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 

--- a/src/gltests/texture-array-2d/main.c
+++ b/src/gltests/texture-array-2d/main.c
@@ -49,9 +49,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint texAllPixels[] = { 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 

--- a/src/gltests/texture-array-nonzerobase/main.c
+++ b/src/gltests/texture-array-nonzerobase/main.c
@@ -49,9 +49,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint texAllPixels[] = { 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 

--- a/src/gltests/texture-array-subimages/main.c
+++ b/src/gltests/texture-array-subimages/main.c
@@ -49,9 +49,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint tex0Pixels[] = { 0xFF0000FF, 0xFF0000FF, 0xFF0000FF, 0xFF0000FF };

--- a/src/gltests/texture-nonzerobase/main.c
+++ b/src/gltests/texture-nonzerobase/main.c
@@ -49,9 +49,7 @@ int main( /* int argc, char* args[] */ )
     }
 
     SDL_GLContext maincontext = SDL_GL_CreateContext(window); /* Our opengl context handle */
-    #ifndef NDEBUG
     assert(maincontext != NULL);
-    #endif
     SDL_GL_SetSwapInterval(1);
 
     GLint level5Pixels[] = { 0xFF00FFFF, 0xFF00FF00, 0xFFFF0000, 0xFF000000 };


### PR DESCRIPTION
Added a check of SDL_GLContext;

src/gltests/include/testcommon.h:
  (1) added assert header when enabling debugging (check is on NDEBUG not being defined);

src/gltests/core-vao/main.c
src/gltests/fixedfunc-multitexcoord-2d/main.c
src/gltests/msaa_depthstencil/main.c
src/gltests/texture-array-1d/main.c
src/gltests/texture-array-2d-msaa/main.c
src/gltests/texture-array-2d/main.c
src/gltests/texture-array-nonzerobase/main.c
src/gltests/texture-array-subimages/main.c
src/gltests/texture-nonzerobase/main.c
  (1) added an assert on the SDL_GLContext being valid;
      why: Open source drivers currently support up to specific OpenGL context
           - so fail early (in order to avoid failure later in the code);
