### PR TITLE
.gitignore: libbacktrace.a now libbacktracevogl.a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ qtcreator/rules.ninja
 
 src/libbacktrace/backtrace-supported.h
 src/libbacktrace/config.h
-src/libbacktrace/libbacktrace.a
+src/libbacktrace/libbacktracevogl.a
 src/voglcore/libvoglcore.a
 src/voglcommon/libvoglcommon.a
 src/vogleditor/moc_vogleditor*


### PR DESCRIPTION
Somewhere along the line, libbacktrace.a, previously ignored, changed
names to libbacktracevogl.a

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
