### PR TITLE
vogleditor: add nested operations check

### DIFF
--- a/src/voglcommon/vogl_gl_utils.cpp
+++ b/src/voglcommon/vogl_gl_utils.cpp
@@ -1344,6 +1344,36 @@ bool vogl_is_clear_entrypoint(gl_entrypoint_id_t id)
     return false;
 }
 
+//------------------------------------------------------------------------------
+// vogl_is_start_nested_entrypoint
+//------------------------------------------------------------------------------
+bool vogl_is_start_nested_entrypoint(gl_entrypoint_id_t id)
+{
+    switch (id) {
+        case VOGL_ENTRYPOINT_glBegin:
+        case VOGL_ENTRYPOINT_glPushDebugGroup:
+          return true;
+        default:
+          break;
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------------
+// vogl_is_end_nested_entrypoint
+//------------------------------------------------------------------------------
+bool vogl_is_end_nested_entrypoint(gl_entrypoint_id_t id)
+{
+    switch (id) {
+        case VOGL_ENTRYPOINT_glEnd:
+        case VOGL_ENTRYPOINT_glPopDebugGroup:
+          return true;
+        default:
+          break;
+    }
+    return false;
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 // vogl_get_json_value_as_enum
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/voglcommon/vogl_gl_utils.h
+++ b/src/voglcommon/vogl_gl_utils.h
@@ -379,6 +379,8 @@ inline bool vogl_is_swap_buffers_entrypoint(gl_entrypoint_id_t id)
 
 bool vogl_is_draw_entrypoint(gl_entrypoint_id_t id);
 bool vogl_is_clear_entrypoint(gl_entrypoint_id_t id);
+bool vogl_is_start_nested_entrypoint(gl_entrypoint_id_t id);
+bool vogl_is_end_nested_entrypoint(gl_entrypoint_id_t id);
 
 //----------------------------------------------------------------------------------------------------------------------
 // Error helpers

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -239,15 +239,16 @@ void vogleditor_QApiCallTreeModel::setupModelData(vogl_trace_file_reader* pTrace
             // reset the CurFrame so that a new frame node will be created on the next api call
             pCurFrame = NULL;
          }
-         else if (entrypoint_id == VOGL_ENTRYPOINT_glBegin)
+         else if (vogl_is_start_nested_entrypoint(entrypoint_id))
          {
-             // items in the glBegin/glEnd block will be nested, including the glEnd
+             // Nest logically paired blocks of gl calls including terminating
+             // nest call
              pCurParent = item;
          }
-         else if (entrypoint_id == VOGL_ENTRYPOINT_glEnd)
+         else if (vogl_is_end_nested_entrypoint(entrypoint_id))
          {
              // move the parent back one level of the hierarchy, to its own parent
-             // (but not past Frame parent [e.g., unpaired "glEnd" operation])
+             // (but not past Frame parent [e.g., unpaired "end" operation])
              if (pCurParent->parent() != parent)
                  pCurParent = pCurParent->parent();
          }


### PR DESCRIPTION
A check is added at the "glEnd" entrypoint to ensure it doesn't get
moved past the parent frame in the case of an unpaired glEnd(). This
can inadvertently occur in a program and will cause a crash. (Similar
defect in apitrace)

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
