### PR TITLE
Adding cstddef header to voglcommon/gl_types.h

### DIFF
--- a/src/voglcommon/gl_types.h
+++ b/src/voglcommon/gl_types.h
@@ -26,6 +26,7 @@
 
 
 #include "vogl_build_options.h"
+#include <cstddef>
 
 // Int type large enough to hold a pointer
 typedef intptr_t GLsizeiptr;


### PR DESCRIPTION
- Fixes error: 'ptrdiff_t' does not name a type on gcc 4.6
