### PR TITLE
Configure SDL2 for voglreplay on Linux.

### DIFF
--- a/src/build_options.cmake
+++ b/src/build_options.cmake
@@ -377,9 +377,10 @@ function(require_libjpegturbo)
 endfunction()
 
 function(require_sdl2)
-    # TODO for linux
-    # find_package(SDL2)
-    if (MSVC)
+	if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+		include(FindPkgConfig)
+		pkg_search_module(SDL2 REQUIRED sdl2)
+	elseif (MSVC)
         set(SDL2Root "${CMAKE_EXTERNAL_PATH}/SDL")
 
         set(SDL2_INCLUDE "${SDL2Root}/include" PARENT_SCOPE)

--- a/src/voglreplay/CMakeLists.txt
+++ b/src/voglreplay/CMakeLists.txt
@@ -5,7 +5,7 @@ include("${SRC_DIR}/build_options.cmake")
 
 require_pthreads()
 
-if (MSVC)
+if ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR MSVC)
     require_sdl2()
 endif()
 
@@ -21,9 +21,13 @@ include_directories(
     ${SRC_DIR}/voglcommon
 	${SRC_DIR}/libtelemetry
 	${SRC_DIR}/extlib/loki/include/loki
-	${SDL2_INCLUDE}
-
 )
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	include_directories(${SDL2_INCLUDE_DIRS})
+elseif(MSVC)
+	include_directories(${SDL2_INCLUDE})
+endif()
 
 set(SRC_LIST
     ${SRC_LIST}
@@ -55,6 +59,12 @@ target_link_libraries(${PROJECT_NAME}
     voglcore
     ${SDL2_LIBRARY}
 )
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES})
+elseif(MSVC)
+	target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARY})
+endif()
 
 build_options_finalize()
 


### PR DESCRIPTION
Use pkg-config to add the SDL2 library to voglreplay in Linux builds.
