### PR TITLE
Build fix for glxspheres on Linux

### DIFF
--- a/src/glxspheres/CMakeLists.txt
+++ b/src/glxspheres/CMakeLists.txt
@@ -42,5 +42,12 @@ target_link_libraries(${PROJECT_NAME}
     ${SDL2_LIBRARY}
     )
 
+if(NOT MSVC)
+    find_package(X11 REQUIRED)
+    target_link_libraries(${PROJECT_NAME}
+	${X11_X11_LIB}
+    )
+endif()
+
 build_options_finalize()
 


### PR DESCRIPTION
The last commit that changed glxspheres to an SDL version was a bit quick to remove build options needed for Linux, I added them back in. 
Shouldn't break build on Windows, but I didn't test that.
