### PR TITLE
cmake: set SDL2_LIBRARY to an absolute path

### DIFF
--- a/src/build_options.cmake
+++ b/src/build_options.cmake
@@ -384,7 +384,7 @@ function(require_sdl2)
 		pkg_search_module(SDL2 REQUIRED sdl2)
 
         set(SDL2_INCLUDE "${SDL2_INCLUDE_DIRS}" PARENT_SCOPE)
-        set(SDL2_LIBRARY "${SDL2_LIBRARIES}" PARENT_SCOPE)
+	set(SDL2_LIBRARY "${SDL2_PREFIX}/lib/libSDL2.so" PARENT_SCOPE)
 	elseif (MSVC)
         set(SDL2Root "${CMAKE_EXTERNAL_PATH}/SDL")
 


### PR DESCRIPTION
Previously the build ignored the prefix for SDL2 discovered via
pkg-config and linking with only -lSDL2 could result in trying to link
to a system SDL2 instead of some custom SDL2 build.

In my case I'm building vogl for 32 bit and 64 bit on a multilib
system and although pkg-config is setup to find a 32bit build of
SDL, the vogl build was trying to link with my system's 64 bit
library.
