### PR TITLE
cmake: handle libm, libGL, libGLU and libSDL2 checks consistently

### DIFF
--- a/src/build_options.cmake
+++ b/src/build_options.cmake
@@ -379,30 +379,35 @@ function(require_libjpegturbo)
 endfunction()
 
 function(require_sdl2)
-	if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-		include(FindPkgConfig)
-		pkg_search_module(SDL2 REQUIRED sdl2)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        include(FindPkgConfig)
+        pkg_search_module(PC_SDL2 REQUIRED sdl2)
 
-        set(SDL2_INCLUDE "${SDL2_INCLUDE_DIRS}" PARENT_SCOPE)
-        set(SDL2_LIBRARY "${SDL2_LIBRARIES}" PARENT_SCOPE)
-	elseif (MSVC)
+        find_path(SDL2_INCLUDE SDL.h
+            DOC "SDL2 Include Path"
+	    HINTS ${PC_SDL2_INCLUDEDIR} ${PC_SDL2_INCLUDE_DIRS} )
+
+        find_library(SDL2_LIBRARY SDL2
+            DOC "SDL2 Library"
+	    HINTS ${PC_SDL2_LIBDIR} ${PC_SDL2_LIBRARY_DIRS} )
+    elseif (MSVC)
         set(SDL2Root "${CMAKE_EXTERNAL_PATH}/SDL")
 
-        set(SDL2_INCLUDE "${SDL2Root}/include" PARENT_SCOPE)
-        set(SDL2_LIBRARY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/SDL2.lib" PARENT_SCOPE)
+        set(SDL2_INCLUDE "${SDL2Root}/include" CACHE PATH "SDL2 Include Path")
+        set(SDL2_LIBRARY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/SDL2.lib" CACHE FILEPATH "SDL2 Library")
 
         # Only want to include this once.
         # This has to go into properties because it needs to persist across the entire cmake run.
         get_property(SDL_PROJECT_ALREADY_INCLUDED 
             GLOBAL 
             PROPERTY SDL_PROJECT_INCLUDED
-        )
+            )
 
         if (NOT SDL_PROJECT_ALREADY_INCLUDED)
             INCLUDE_EXTERNAL_MSPROJECT(SDL "${SDL2Root}/VisualC/SDL/SDL_VS2013.vcxproj")
             set_property(GLOBAL
                 PROPERTY SDL_PROJECT_INCLUDED "TRUE"
-            )
+                )
             message("Including SDL_VS2013.vcxproj for you!")
         endif()
 
@@ -411,6 +416,55 @@ function(require_sdl2)
     endif()
 endfunction()
 
+function(require_m)
+    if (MSVC)
+	set(M_LIBRARY "winmm.lib" PARENT_SCOPE)
+    else()
+	set(M_LIBRARY "m" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(require_gl)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	include(FindPkgConfig)
+	pkg_search_module(PC_GL QUIET gl)
+
+	find_path(GL_INCLUDE GL/gl.h
+	    DOC "OpenGL Include Path"
+	    HINTS ${PC_GL_INCLUDEDIR} ${PC_GL_INCLUDE_DIRS} )
+
+	find_library(GL_LIBRARY GL
+	    DOC "OpenGL Library"
+	    HINTS ${PC_GL_LIBDIR} ${PC_GL_LIBRARY_DIRS} )
+    elseif (MSVC)
+	set(GL_INCLUDE ""	      CACHE PATH "OpenGL Include Path")
+	set(GL_LIBRARY "opengl32.lib" CACHE FILEPATH "OpenGL Library")
+    else()
+	set(GL_INCLUDE ""   CACHE PATH "OpenGL Include Path")
+	set(GL_LIBRARY "GL" CACHE FILEPATH "OpenGL Library")
+    endif()
+endfunction()
+
+function(require_glu)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	include(FindPkgConfig)
+	pkg_search_module(PC_GLU QUIET glu)
+
+	find_path(GLU_INCLUDE GL/glu.h
+	    DOC "GLU Include Path"
+	    HINTS ${PC_GLU_INCLUDEDIR} ${PC_GLU_INCLUDE_DIRS} )
+
+	find_library(GLU_LIBRARY GLU
+	    DOC "GLU Library"
+	    HINTS ${PC_GLU_LIBDIR} ${PC_GLU_LIBRARY_DIRS} )
+    elseif (MSVC)
+	set(GLU_INCLUDE ""	    CACHE PATH "GLU Include Path")
+	set(GLU_LIBRARY "glu32.lib" CACHE FILEPATH "GLU Library")
+    else()
+	set(GLU_INCLUDE ""    CACHE PATH "GLU Include Path")
+	set(GLU_LIBRARY "GLU" CACHE FILEPATH "GLU Library")
+    endif()
+endfunction()
 
 function(request_backtrace)
     if (NOT MSVC)

--- a/src/glxspheres/CMakeLists.txt
+++ b/src/glxspheres/CMakeLists.txt
@@ -5,27 +5,18 @@ include("${SRC_DIR}/build_options.cmake")
 
 require_pthreads()
 require_sdl2()
+require_m()
+require_gl()
+require_glu()
 
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     add_definitions(-Wno-documentation)
 endif()
 
-if (MSVC)
-    set(VOGLTEST_OPENGL_LIBRARY
-        winmm.lib
-        opengl32.lib
-        glu32.lib
-    )
-else()
-    set(VOGLTEST_OPENGL_LIBRARY
-        m
-        GL
-        GLU
-    )
-endif()
-
 include_directories(
+    ${GL_INCLUDE}
+    ${GLU_INCLUDE}
     ${SDL2_INCLUDE}
     )
 
@@ -38,7 +29,9 @@ add_dependencies(${PROJECT_NAME} SDL)
 
 target_link_libraries(${PROJECT_NAME}
     ${CMAKE_DL_LIBS}
-    ${VOGLTEST_OPENGL_LIBRARY}
+    ${M_LIBRARY}
+    ${GL_LIBRARY}
+    ${GLU_LIBRARY}
     ${SDL2_LIBRARY}
     )
 

--- a/src/vogltest/CMakeLists.txt
+++ b/src/vogltest/CMakeLists.txt
@@ -5,6 +5,9 @@ include("${SRC_DIR}/build_options.cmake")
 
 require_pthreads()
 require_sdl2()
+require_m()
+require_gl()
+require_glu()
 
 # option(VOGLTEST_LOAD_LIBVOGLTRACE "If enabled vogltest will load libvogltrace.so manually and not implictly link against libgl.so" FALSE)
 # message("VOGLTEST_LOAD_LIBGLITRACE: ${VOGLTEST_LOAD_LIBVOGLTRACE}")
@@ -31,22 +34,10 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     add_definitions(-Wno-documentation)
 endif()
 
-if (MSVC)
-    set(VOGLTEST_OPENGL_LIBRARY
-        winmm.lib
-        opengl32.lib
-        glu32.lib
-    )
-else()
-    set(VOGLTEST_OPENGL_LIBRARY
-        m
-        GL
-        GLU
-    )
-endif()
-
 include_directories(
     ${SRC_DIR}/voglcore
+    ${GL_INCLUDE}
+    ${GLU_INCLUDE}
     ${SDL2_INCLUDE}
     )
 
@@ -61,7 +52,9 @@ add_dependencies(${PROJECT_NAME} SDL)
 target_link_libraries(${PROJECT_NAME}
     ${CMAKE_DL_LIBS}
     voglcore
-    ${VOGLTEST_OPENGL_LIBRARY}
+    ${M_LIBRARY}
+    ${GL_LIBRARY}
+    ${GLU_LIBRARY}
     ${SDL2_LIBRARY}
     )
 


### PR DESCRIPTION
This adds require_{m,gl,glu} functions to build_options.cmake;
consistent with the require_sdl2 function. These are now used to check
dependencies for glxspheres and vogltest.

Except for require_m, all of these functions use cmake's built in
find_path and find_library functions, passing them pkg-config data in as
'HINTS' which, as far as I can tell, seems to be the recommended pattern
for using pkg-config with cmake.

Notably this now means we use pkg-config to look for libGL and libGLU so
developers can optionally manage which specific libraries they build
against using standard pkg-config environment variables on Linux. It's
now also possible to explicitly override the library and include paths
for these as cached cmake variables.

I've at least tested this patch building 32 bit and 64 bit vogl on my multilib Arch Linux machine where I'm using pkg-config in both cases to point the build at some manually built debug binaries for mesa and sdl2. I've tried to make sure the MSVC paths essentially work as they did before but haven't been able to test them.
