### PR TITLE
README.md (2): missed an update in previous commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://bitbucket.org/raddebugger/vogl_chroot/src/master/bin/chroot_configure.sh
 ```
 git clone https://github.com/ValveSoftware/vogl.git  
 mkdir -p vogl/vogl_build/release64 && cd $_  
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_X64=On ../../..  
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_X64=On ../..
 make -j 10
 ```
 


### PR DESCRIPTION
In previous commit to update instructions relative to removal of bin/

```
7670eb3 README.md: replace reference to vogl_build/bin/
```

, missed updating the path

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
