### PR TITLE
UI: Timeline with nested calls

### DIFF
--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -103,6 +103,7 @@ private:
 
    void drawBaseTimeline(QPainter* painter, const QRect& rect, int gap);
    void drawTimelineItem(QPainter* painter, vogleditor_timelineItem* pItem, int height, float &minimumOffset);
+   bool drawCurrentApiCallMarker(QPainter* painter, QPolygon& triangle, vogleditor_timelineItem* pItem);
 
    float scaleDurationHorizontally(float value);
    float scalePositionHorizontally(float value);


### PR DESCRIPTION
Patch for issue #52:
vogleditor: timeline does not display apicalls which are nested in the
            tree control
## Cause
- vogleditor_QTimelineView::paint()
  
  The search for the apicall at which to draw the timeline marker
  was only looking at the top-level apicalls. If the apicall was
  nested then it wasn't checked.
- vogleditor_QTimelineView::drawTimelineView()
  
  If the top-level apicall's duration didn't meet the threshold for
  drawing its location on the timeline then its children were also
  skipped.
## Patch
- vogleditor_QTimelineView::paint()
  
  Add recursive checking for nested apicall items
- vogleditor_QTimelineView::drawTimelineView()
  
  Regardless whether the parent duration met the threshold, continue
  looking at the children. If the threshold is met for the child then
  the child's location is drawn on the timeline.
## Testing

A version of glxgears that has 3 levels of nested apicalls using
glPushDebugGroup/glPopDebugGroup and glBegin/glEnd (bin file attached)

Timeline ignoring nested apicalls:
![no-nesting-timeline](https://cloud.githubusercontent.com/assets/6090880/3560209/75a208c0-095d-11e4-838f-5e08a6e7c954.png)

Timeline with nested  apicalls:
![nesting-timeline](https://cloud.githubusercontent.com/assets/6090880/3560211/862fdaa0-095d-11e4-899f-aebf5f4eee2e.png)

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
