### PR TITLE
Use PxFmt library for vogleditor texture views rather than mipmapped_tex...

### DIFF
--- a/src/vogleditor/CMakeLists.txt
+++ b/src/vogleditor/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(
     ${SRC_DIR}/voglcommon
     ${CMAKE_BINARY_DIR}/voglinc
     ${SRC_DIR}/extlib/loki/include/loki
+    ${SRC_DIR}/extlib/pxfmt
     ${SRC_DIR}/libtelemetry
     ${CMAKE_CURRENT_BINARY_DIR}
     ${Qt5Widgets_INCLUDE_DIRS}
@@ -184,6 +185,7 @@ target_link_libraries(${PROJECT_NAME}
     ${LibBackTrace_LIBRARY}
     voglcommon
     voglcore
+    pxfmt
     ${CMAKE_DL_LIBS}
     ${SDL2_LIBRARY}
     ${X11_X11_LIB}

--- a/src/vogleditor/vogleditor_qtextureviewer.h
+++ b/src/vogleditor/vogleditor_qtextureviewer.h
@@ -38,7 +38,7 @@ QT_END_NAMESPACE
 
 #include "vogl_core.h"
 #include "vogl_map.h"
-#include "vogl_mipmapped_texture.h"
+#include "vogl_image.h"
 #include "vogl_ktx_texture.h"
 
 typedef enum ChannelSelectionOptions
@@ -82,11 +82,22 @@ public:
         }
     }
 
+    void deleteTexture()
+    {
+        for (vogl::vector<vogl::image_u8*>::iterator it = m_image.begin(); it < m_image.end(); ++it)
+        {
+            vogl::image_u8 *img = *it;
+            img->clear();
+            vogl_delete(img);
+        }
+        m_image.clear();
+    }
+
     void clear()
     {
         m_draw_enabled = false;
         m_pKtxTexture = NULL;
-        m_mipmappedTexture.clear();
+        deleteTexture();
     }
 
     inline QColor getBackgroundColor() const { return m_background.color(); }
@@ -161,7 +172,7 @@ private:
     vogl::map<uint, vogl::color_quad_u8*> m_pixmapData;
 
     const vogl::ktx_texture* m_pKtxTexture;
-    vogl::mipmapped_texture m_mipmappedTexture;
+    vogl::vector<vogl::image_u8*> m_image;
     uint m_baseMipLevel;
     uint m_maxMipLevel;
     uint m_arrayIndex;


### PR DESCRIPTION
Start using the PxFmt library for displaying textures, framebuffers, renderbuffers, etc. in vogleditor (qtextureview
Remove usage of mipmapped_texture class from qtextureviewer.  Mipmapped_texture files could be removed if the last few places where it is used were cleaned up.
