### PR TITLE
Null shader and Frame Analysis capability

### DIFF
--- a/scripts/vogl_analysis.py
+++ b/scripts/vogl_analysis.py
@@ -1,0 +1,277 @@
+
+import argparse
+import os
+import subprocess
+import sys
+import json
+import zipfile
+from pprint import pprint
+
+# vogl_analysis.py overview
+# Initially this script automates frag shader performance analysis per frame
+#   Over time it may grow to include per-draw debug analysis as well as other features
+# Here's the current high-level view of how it performs frame perf analysis.
+#   1. Take a bin file and specified frame as input (along with various other options)
+#   2. Perform dump on bin file and analyze state to identify FSs that are used for given frame
+#   3. Run the trace for specified loop count (default 100) on specified frame and record FPS as baseline
+#   4. Foreach FS used in the frame:
+#      a. Null out FS (make it output constant color)
+#      b. Run trace for loop count over given frame
+#      c. Record FPS w/ this FS NULL
+#   5. Report out FPS vs. baseline for each null FS
+
+
+def handle_args():
+    parser = argparse.ArgumentParser(description='Perform analysis of vogl trace.')
+    parser.add_argument('trace_bin_file', help='The VOGL .bin trace file on which to perform analysis.')
+    parser.add_argument('--vogl_path', required=True,  help='Path to vogl executable used to replay trace.')
+    parser.add_argument('--fs_pp_path', required=True,  help='Path to FS pre-processor.')
+    parser.add_argument('--vogl_args',  default='--loop_frame 1 --loop_len 1 --benchmark',  help='Arguments to pass along to VOGL. NOTE: "--loop_count" is also added based on that option.')
+    parser.add_argument('--loop_count', type=int, default=100, help='Number of times to loop.')
+    parser.add_argument('--frame', dest='frame_num', type=int,  help='The frame on which analysis is performed.')
+    parser.add_argument('--dump_images', action='store_true', default=False, help='Create "img_dump" dir where bin file is and dump frame images there.')
+    parser.add_argument('--rename_images', action='store_true', default=False, help='Renames images in "img_dump" dir to simplify sorting. Must also specify "--dump_images".')
+    parser.add_argument('--dump_shaders', action='store_true', default=False, help='Create "shader_dump" dir where bin file is and dump input & output shaders there.')
+    parser.add_argument('--debug_quit_after_num', type=int, default=0, help='Debug option, provide an int and and testing will quit after that many NULL FSs.')
+    return parser.parse_args()
+
+def print_stats(stat_dict, time_dict):
+    # sort results to identify FS usage
+    print("Baseline FPS: %s" % time_dict['baseline_fps'])
+    print("Baseline Time: %s" % time_dict['baseline_time'])
+    for fps in sorted(time_dict['fps'],  reverse=True):
+        for fs in sorted(time_dict['fps'][fps]):
+            print("Ran at %s fps in %ss w/ FS#%s NULL which is %.4f percent of baseline FPS" % (fps, stat_dict["shader_dict"][fs]["loop_time"], fs, float(fps)/float(time_dict['baseline_fps'])))
+
+def find_index(in_list,  str_to_match):
+    index = 0
+    for item in in_list:
+        if str_to_match in item:
+            return index
+        index += 1
+    return -1
+
+# This is a convenience function to rename image files so they're easier to sort through
+#  By default frame number is at the end of image name and this function puts it at the
+#  front so that all images from same frame will be grouped together
+# This function will also delete images that aren't for the frame of interest
+def rename_images(opts, img_dir):
+    frame_str = "%07d" % opts.frame_num;
+    # loop through files in img_dir, renaming frames of interest and deleting others
+    for f in os.listdir(img_dir):
+        if frame_str in f:
+            # rename this file
+            new_name = "%s_%s" % (frame_str,  f.replace("_%s" % frame_str,  ''))
+            #print("Renaming %s to %s" % (f,  new_name))
+            os.rename(os.path.join(img_dir, f), os.path.join(img_dir, new_name))
+        else:
+            # delete this file
+            if os.path.isfile(os.path.join(img_dir, f)):
+                #print("Removing file %s" % os.path.join(img_dir, f))
+                os.remove(os.path.join(img_dir, f))
+
+# Run the trace with the given options
+#  Do initial baseline run and then re-run with each shader substituted to NULL
+#  If dumping images is requested, do that in a separate run to avoid affecting perf numbers on looping
+def run_trace(opts,  stat_dict):
+    count = 0
+    time_dict = {}
+    time_dict['fps'] = {}
+    time_dict['time'] = {}
+    # First get baseline time w/o any null shaders
+    if opts.dump_images:
+        img_dir = os.path.join(os.path.dirname(opts.trace_bin_file),  "dump_imgs")
+        if not os.path.exists(img_dir):
+            os.mkdir(img_dir)
+        img_prefix = os.path.join(img_dir,  "default")
+        print("\tWill dump frame images to '%s'" % img_dir)
+        print("\tDumping default image for frame %i" % (opts.frame_num))
+        cmd_string = "%s replay --dump_screenshots --dump_screenshots_prefix %s %s" % (opts.vogl_path, img_prefix, opts.trace_bin_file)
+        p = subprocess.Popen(cmd_string.split(),  stdout=subprocess.PIPE)
+        out,  err = p.communicate()
+    cmd_string = "%s replay %s --loop_count %s %s" % (opts.vogl_path, opts.vogl_args, opts.loop_count,  opts.trace_bin_file)
+    p = subprocess.Popen(cmd_string.split(),  stdout=subprocess.PIPE)
+    out,  err = p.communicate()
+    out_list = out.split()
+    time_dict['baseline_fps'] = out_list[find_index(out_list, "Looping:")+6]
+    time_dict['baseline_time'] = out_list[find_index(out_list, "Looping:")+4]
+    #print("Baseline FPS: %s" % baseline_fps)
+    for fs in stat_dict["shader_dict"]:
+        print("\tRunning with FS #%s NULL'd out" % (fs))
+        print("\t\tFS #%s is used in %s draws w/ %s total tris" % (fs, stat_dict["shader_dict"][fs]["num_draws"], stat_dict["shader_dict"][fs]["num_tris"]))
+        if opts.dump_images:
+            img_prefix = os.path.join(img_dir,  "null_fs%s" % (fs))
+            print("\tDumping image w/ NULL FS#%s for frame %i" % (fs, opts.frame_num))
+            cmd_string = "%s replay --dump_screenshots --dump_screenshots_prefix %s --fs_preprocessor %s --fs_preprocessor_options NULL_FS[%s] %s" % (opts.vogl_path, img_prefix, opts.fs_pp_path, fs, opts.trace_bin_file)
+            p = subprocess.Popen(cmd_string.split(),  stdout=subprocess.PIPE)
+            out,  err = p.communicate()
+        cmd_string = "%s replay %s --loop_count %s --fs_preprocessor %s --fs_preprocessor_options NULL_FS[%s] %s" % (opts.vogl_path, opts.vogl_args, opts.loop_count, opts.fs_pp_path, fs, opts.trace_bin_file)
+        if opts.dump_shaders:
+            shader_dir = os.path.join(os.path.dirname(opts.trace_bin_file),  "dump_shaders")
+            if not os.path.exists(shader_dir):
+                os.mkdir(shader_dir)
+            shader_prefix = os.path.join(shader_dir,  "analysis_")
+            cmd_string += " --fs_preprocessor_prefix %s" % shader_prefix
+        cmd_list = cmd_string.split()
+        #print(" ".join(cmd_list))
+        p = subprocess.Popen(cmd_list,  stdout=subprocess.PIPE)
+        out,  err = p.communicate()
+        #print(out)
+        # parse out loop time and store in stats
+        out_list = out.split()
+        loop_index = find_index(out_list,  "Looping:")
+        if loop_index < 0:
+            print("WARN: Bad output data for NULL FS#%s, did something go wrong?" % fs)
+        else:
+            loop_time = out_list[loop_index+4]
+            loop_fps = out_list[loop_index+6]
+            #print("Loop FPS: %s" % loop_fps)
+            stat_dict["shader_dict"][fs]["loop_time"] = loop_time
+            stat_dict["shader_dict"][fs]["loop_fps"] = loop_fps
+            # Store a list of FSs per time/fps in case 2+ FSs hit same value
+            if loop_fps in time_dict['fps']: #append to existing list
+                time_dict['fps'][loop_fps].append(fs)
+            else: #create new list
+                time_dict['fps'][loop_fps] = [fs, ]
+            if loop_time in time_dict['time']:
+                time_dict['time'][loop_time].append(fs)
+            else:
+                time_dict['time'][loop_time] = [fs, ]
+        count += 1
+        if opts.debug_quit_after_num > 0 and count > opts.debug_quit_after_num:
+            print("Option '--debug_quit_after_num %i' given so quitting now." % opts.debug_quit_after_num)
+            break;
+    if opts.dump_images and opts.rename_images:
+        rename_images(opts, img_dir)
+    return (stat_dict,  time_dict)
+
+# Having difficulty with json parsing so just parsing file line-by-line for now
+def parse_shader_state_file(state_file):
+    shader_dict = {}
+    parse_prog = False
+    grab_prog_handle = False
+    grab_shader_type = False
+    grab_shader_handle = False
+    prog_handle = 0
+    shader_type = "NULL"
+    shader_handle = 0
+    with open(state_file) as in_file:
+        for line in in_file:
+            if parse_prog:
+                if 'link_time_snapshot' in line:
+                    grab_prog_handle = True
+                if 'handle' in line:
+                    if grab_prog_handle:
+                        #print("grab_prog_handle")
+                        prog_handle = line[line.find(':')+2:line.find(',')]
+                        shader_dict[prog_handle] = {}
+                        #pprint(shader_dict)
+                        grab_prog_handle = False
+                    elif grab_shader_handle:
+                        #print("grab_shader_handle")
+                        shader_handle = line[line.find(':')+2:line.find(',')]
+                        grab_shader_type = True
+                if 'type' in line and grab_shader_type:
+                    #print("grab_shader_type")
+                    shader_type = line[line.find(':')+3:line.find(',')-1]
+                    shader_dict[prog_handle][shader_type] = shader_handle
+                    #pprint(shader_dict)
+                    grab_shader_type = False
+                if 'shader_objects' in line:
+                    grab_shader_handle = True
+                if '],' in line and grab_shader_handle:
+                    grab_shader_handle = False
+            if 'Program' in line:
+                #print("Found Program")
+                parse_prog = True
+    #pprint(shader_dict)
+    return shader_dict
+
+def parse_frame_file(frame_file,  shader_program_dict):
+    stat_dict = {}
+    stat_dict["shader_dict"] = {}
+    # alternate way to store data for simplified sorting by time values
+    stat_dict["results"] = {}
+    stat_dict["results"]["fps"] = {}
+    stat_dict["results"]["times"] = {}
+    total_time = 0.0
+    cur_program = "0x0"
+    with open(frame_file) as in_file:
+        frame_data = json.load(in_file)
+        #print("Analyzing frame %i" % frame_data["meta"]["cur_frame"])
+        for element in frame_data["packets"]:
+            #pprint(element)
+            if 'glUseProgram' in element["func"]:
+                cur_program = str(int(element["params"]["program"],  0))
+            if 'glDraw' in element["func"]:
+                if "count" in element["params"]:
+                    #print("gl Call #%i is draw of %i %s w/ Program %s" % (element["call_counter"], element["params"]["count"], element["params"]["mode"], cur_program))
+                    if cur_program in shader_program_dict:
+                        #print("\tProg %s uses FS %s & VS %s" % (cur_program,  shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"],  shader_program_dict[cur_program]["GL_VERTEX_SHADER"]))
+                        if shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"] not in stat_dict["shader_dict"]:
+                            stat_dict["shader_dict"][shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"]] = {}
+                            stat_dict["shader_dict"][shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"]]["num_draws"] = 0
+                            stat_dict["shader_dict"][shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"]]["num_tris"] = 0
+                            stat_dict["shader_dict"][shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"]]["tot_time"] = 0.0
+                        stat_dict["shader_dict"][shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"]]["num_draws"] += 1
+                        stat_dict["shader_dict"][shader_program_dict[cur_program]["GL_FRAGMENT_SHADER"]]["num_tris"] += element["params"]["count"]
+                    else:
+                        print("\tWARN: Don't have Prog %s in shader_prog_dict!" % (cur_program))
+                else:
+                    pass
+                    #print("\tgl Call #%i is type %s w/o a count" % (element["call_counter"], element["func"]))
+    #pprint(stat_dict)
+    return stat_dict, total_time
+
+# identify and return state snapshot and frame api files
+def find_api_and_state_json_files(dir, prefix,  frame_num):
+    frame_api_name = "%s_%06d.json" % (prefix,  int(frame_num))
+    frame_api_file = os.path.join(dir,  frame_api_name)
+    if not os.path.exists(frame_api_file):
+        print("ERROR: Can't find API dump file %s" % frame_api_file)
+    for f in os.listdir(dir):
+        if 'state_snapshot' in f and 'json' in f:
+            ss_json = os.path.join(dir,  f)
+            return (frame_api_file,  ss_json)
+
+def run_vogl_dump(opts):
+    # check if dump dir exists
+    bin_path = os.path.dirname(opts.trace_bin_file)
+    bin_dump_path = os.path.join(bin_path,  "dump")
+    prefix = "vogl_analysis"
+    if (os.path.exists(bin_dump_path)):
+        print("\tFYI: Path '%s' already exists so not running VOGL dump. To force a re-dump of trace data, please remove or rename that dir." % bin_dump_path)
+        return find_api_and_state_json_files(bin_dump_path,  prefix, opts.frame_num)
+    # run vogl w/ dump, outputting to dump dir
+    os.mkdir(bin_dump_path)
+    dump_prefix = os.path.join(bin_dump_path,  prefix)
+    vogl_dump_cmd = "%s dump %s %s" % (opts.vogl_path, opts.trace_bin_file,  dump_prefix)
+    print("Dump cmd: %s" % vogl_dump_cmd)
+    p = subprocess.Popen(vogl_dump_cmd.split(),  stdout=subprocess.PIPE)
+    out,  err = p.communicate()
+    # identify zip file and extract it to dump dir
+    for f in os.listdir(bin_dump_path):
+        if '_trace_archive' in f and 'zip' in f:
+            print("Found zip file: %s" % f)
+            full_zip_path = os.path.join(bin_dump_path,  f)
+            zf = zipfile.ZipFile(full_zip_path)
+            zf.extractall(bin_dump_path)
+            
+    return find_api_and_state_json_files(bin_dump_path,  prefix, opts.frame_num)
+
+def main(argv=None):
+    opts = handle_args()
+    #print(opts)
+    print("STEP1: Run trace in dump mode.")
+    (trace_json,  state_json) = run_vogl_dump(opts)
+    print("STEP2: Parsing state json file to identify FSs per program.")
+    shader_prog_dict = parse_shader_state_file(state_json)
+    print("STEP3: Parsing frame #%i to identify which FSs are used." % (opts.frame_num))
+    stat_dict, time = parse_frame_file(trace_json,  shader_prog_dict)
+    print("STEP4: Run trace with each FS null'd out, looping %i times on frame %i." % (opts.loop_count, opts.frame_num))
+    stat_dict, time_dict = run_trace(opts,  stat_dict)
+    print("STEP5: Print stats")
+    print_stats(stat_dict, time_dict)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/voglbench/voglbench.cpp
+++ b/src/voglbench/voglbench.cpp
@@ -81,6 +81,7 @@ static command_line_param_desc g_command_line_param_descs[] =
     { "debug", 0, false, "Enable verbose debug information" },
     { "fs_preprocessor", 1, false, "Replay: Run all FS through specified pre-processor prior to glCreateShader() call and substitute the shader output by the pre-processor into the glCreateShader() call." },
     { "fs_preprocessor_options", 1, false, "Replay: Options to pass to the FS pre-processor.  Must also specify --fs_preprocessor" },
+    { "fs_preprocessor_prefix", 1, false, "Replay: Dir/prefix to append to FS input to PP and output from PP.  Must also specify --fs_preprocessor" },
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/voglcommon/vogl_fs_preprocessor.cpp
+++ b/src/voglcommon/vogl_fs_preprocessor.cpp
@@ -32,16 +32,24 @@ vogl_fs_preprocessor* vogl_fs_preprocessor::m_instance = 0;
 vogl_fs_preprocessor::vogl_fs_preprocessor()
     : m_pp_cmd(""),
       m_pp_opts(""),
+      m_pp_prefix(""),
       m_count(0),
       m_length(0),
       m_in_length(0),
+      m_shader_id(0),
+      m_null_shader_id(0),
       m_in_shader(""),
       m_output_shader(""),
+      m_null(false),
       m_tm(0),
       m_time_to_run_pp(0),
       m_enabled(false)
 {
     VOGL_FUNC_TRACER
+    m_null_color[0] = 0.6275;
+    m_null_color[1] = 0.1255;
+    m_null_color[2] = 0.9412;
+    m_null_color[3] = 1;
     m_tm.start();
     atexit(&cleanup);
 }
@@ -61,11 +69,19 @@ void vogl_fs_preprocessor::reset()
 {
     m_pp_cmd = "";
     m_pp_opts = "";
+    m_pp_prefix = "";
     m_count = 0;
     m_length = 0;
     m_in_length = 0;
     m_in_shader = "";
+    m_shader_id = 0,
+    m_null_shader_id = 0,
     m_output_shader = "";
+    m_null = false;
+    m_null_color[0] = 0.6275;
+    m_null_color[1] = 0.1255;
+    m_null_color[2] = 0.9412;
+    m_null_color[3] = 1;
     m_tm.stop();
     m_tm.start();
     m_time_to_run_pp = 0;
@@ -75,15 +91,35 @@ void vogl_fs_preprocessor::reset()
 // Internal class function wrapped by public run() call so that we can easily time how long pp takes
 bool vogl_fs_preprocessor::_run()
 {
+    // For NULL case, null FS output prior to PP run
+    //   Also verify any Shader ID
+    if (m_null)
+    {
+        if ((0 != m_null_shader_id) && (m_shader_id != m_null_shader_id))
+        {
+            m_output_shader = m_in_shader;
+            m_count = 1;
+            m_length = m_output_shader.get_len();
+            return true;
+        }
+        m_in_shader = _set_null_output_color(m_in_shader);
+    }
     // Write input shader to a file to feed into pp
+    //dynamic_string in_fs_filename("tmp_shader_in.frag");
     dynamic_string in_fs_filename("tmp_shader_in.frag");
+    if (m_pp_prefix.size() > 0)
+        in_fs_filename = dynamic_string(cVarArg, "%sshader_in_%i.frag", m_pp_prefix.get_ptr(), m_shader_id);
+
     dynamic_string_array shader_strings;
     shader_strings.push_back(m_in_shader);
     bool success = file_utils::write_text_file(in_fs_filename.get_ptr(), shader_strings, true);
     if (success)
     {
-        //const dynamic_string out_shader_filename(cVarArg, "tmp_shader_out_%i.frag", replay_object);
-        const dynamic_string out_shader_filename("tmp_shader_out.frag");
+        dynamic_string out_shader_filename("tmp_shader_out.frag");
+        if (m_pp_prefix.size() > 0)
+            out_shader_filename = dynamic_string(cVarArg, "%sshader_out_%i.frag", m_pp_prefix.get_ptr(), m_shader_id);
+
+        //const dynamic_string out_shader_filename("tmp_shader_out.frag");
         dynamic_string pp_cmd(cVarArg, "%s %s %s 1>%s", m_pp_cmd.get_ptr(), m_pp_opts.get_ptr(), in_fs_filename.get_ptr(), out_shader_filename.get_ptr());
         // TODO : Is "system" best option here?  Add improved error handling.
         system(pp_cmd.get_ptr());
@@ -126,12 +162,143 @@ bool vogl_fs_preprocessor::run()
     return status;
 }
 
-void vogl_fs_preprocessor::set_shader(vogl::vector<const GLcharARB *> in_shader_vec, vogl::vector<GLint> lengths)
+void vogl_fs_preprocessor::set_shader(GLuint id, vogl::vector<const GLcharARB *> in_shader_vec, vogl::vector<GLint> lengths)
 {
+    m_shader_id = id;
     m_in_shader.clear();
     for (unsigned int i = 0; i < in_shader_vec.size(); i++)
     {
         m_in_shader.append(dynamic_string(in_shader_vec[i], lengths[i]));
         m_in_shader.append("\n");
     }
+}
+
+// This function performs null shader substitution by setting FS output color to constant color
+//   The shader will then be cleaned up when run through LunarGOO as the preprocessor
+// TODO : This code is pretty fragile but works on TF2 and Dota2 tests for now
+//   Ideally would like to offload the NULL (and any other capabilities) into the FSPP
+dynamic_string vogl_fs_preprocessor::_set_null_output_color(dynamic_string in_shader)
+{
+    // For the input shader, find "gl_FragColor *;" section and replace with null color
+    // Parse in_shader and find gl_FragColor
+    vogl::vector<const char *> replace_strings(5); // in case we have to replace multiple color outputs
+    replace_strings[0] = "gl_FragColor";
+    replace_strings[1] = "gl_FragData[0]";
+    replace_strings[2] = "gl_FragData[1]";
+    replace_strings[3] = "gl_FragData[2]";
+    replace_strings[4] = "gl_FragData[3]";
+    dynamic_string new_out_color = dynamic_string(cVarArg, "REPLACE_ME = vec4(%1.4f, %1.4f, %1.4f, %1.4f);", m_null_color[0], m_null_color[1], m_null_color[2], m_null_color[3]);
+    dynamic_string replace_me = ""; // the string that we'll replace
+    uint32_t num_found = 0;
+    int32_t out_color_index = in_shader.find_right("gl_FragColor.a =", true);
+    // Special case when glFragColor.a/.rgb are set independently for now
+    if (out_color_index >= 0)
+    {
+        while (';' != in_shader[out_color_index])
+            replace_me.append_char(in_shader[out_color_index++]);
+        replace_me.append_char(';');
+        // Verify that we can do rgb substitution before we replace alpha
+        out_color_index = in_shader.find_right("gl_FragColor.rgb", true);
+        if (out_color_index < 0)
+        {
+            vogl_error_printf("Unable to do NULL substitution for FS %i\n", m_shader_id);
+            VOGL_ASSERT_ALWAYS;
+        }
+        // Just remove gl_FragColor.a line and merge NULL into gl_FragColor.rgb line
+        in_shader.replace(replace_me.get_ptr(), "", true, &num_found, 1);
+        new_out_color.replace("REPLACE_ME", replace_strings[0]);
+        while (';' != in_shader[out_color_index])
+            replace_me.append_char(in_shader[out_color_index++]);
+        replace_me.append_char(';');
+        in_shader.replace(replace_me.get_ptr(), new_out_color.get_ptr(), true, &num_found, 1);
+    }
+    else
+    {
+        for (uint32_t count = 0; count < replace_strings.size(); count++)
+        {
+            out_color_index = in_shader.find_right(replace_strings[count], true);
+            if (out_color_index >= 0)
+            {
+                // need to make this replacement
+                new_out_color.replace("REPLACE_ME", replace_strings[count]);
+                // identify exact string we're replacing
+                while (';' != in_shader[out_color_index])
+                    replace_me.append_char(in_shader[out_color_index++]);
+                replace_me.append_char(';');
+                in_shader.replace(replace_me.get_ptr(), new_out_color.get_ptr(), true, &num_found, 1);
+                if (num_found != 1)
+                {
+                    vogl_warning_printf("Failed to find shader output to replace null shader output\n");
+                }
+                // reset replace strings for next pass
+                replace_me.clear();
+                new_out_color.replace(replace_strings[count], "REPLACE_ME", true, &num_found, 1);
+            }
+        }
+    }
+    return in_shader;
+}
+
+// This is a bit of a work-around that allows us to pull certain options off
+//   of the PP cmd line options and handle them prior to passing further options
+//   onto the PP.  Right now this handles NULL_FS processing.
+//   Default NULL color is bright purple.
+// If "NULL" option found, will be of format NULL_FS[FS_ID]:<#>,<#>,<#>,<#>
+// Here are some examples of ways to use NULL options:
+//      "NULL_FS" will cause all FSs to be nulled out
+//      "NULL_FS[464]" will only null out only FS with trace handle "464"
+//      "NULL_FS:1.0,0.0,0.0,1.0" will NULL all shaders out to red
+//      "NULL_FS[789]:0.0,0.0,1.0,1.0" will NULL out shader with handle "789" to blue
+dynamic_string vogl_fs_preprocessor::_check_opts(const dynamic_string &in_opts)
+{
+    dynamic_string working_str = in_opts;
+    // parse the options and pull off any "internal" options that we deal with ourselves
+    if (working_str.contains("NULL_FS", true))
+    {
+        dynamic_string null_str = "";
+        dynamic_string color_str = "";
+        dynamic_string shader_id_str = "";
+        int ns_start_index = working_str.find_left("NULL_FS");
+        int ns_index = ns_start_index;
+        unsigned int null_color_index = 0;
+        bool store_color = false;
+        bool store_id = false;
+        // Pull NULL str out of opts
+        while (working_str[ns_index] && working_str[ns_index] != ' ')
+        {
+            null_str.append_char(working_str[ns_index]);
+            // if we're in a color section, store color at appropriate index
+            if (store_color)
+            {
+                if (working_str[ns_index] == ',')
+                {
+                    m_null_color[null_color_index++] = strtof(color_str.get_ptr(), NULL);
+                    color_str.clear();
+                }
+                else
+                    color_str.append_char(working_str[ns_index]);
+            }
+            if (store_id)
+            {
+                if (working_str[ns_index] == ']')
+                {
+                    m_null_shader_id = atoi(shader_id_str.get_ptr());
+                    store_id = false;
+                }
+                else
+                    shader_id_str.append_char(working_str[ns_index]);
+            }
+            if (':' == working_str[ns_index])
+                store_color = true;
+            if ('[' == working_str[ns_index])
+                store_id = true;
+            ns_index++;
+        }
+        if (store_color)
+            m_null_color[null_color_index] = strtof(color_str.get_ptr(), NULL);
+        working_str.remove(ns_start_index, null_str.size());
+        //   enable null FS
+        m_null = true;
+    }
+    return working_str;
 }

--- a/src/voglcommon/vogl_fs_preprocessor.h
+++ b/src/voglcommon/vogl_fs_preprocessor.h
@@ -49,9 +49,15 @@ public:
 
     void reset();
     bool run(); // execute pp w/ current cmd, opts & shader
-    void set_shader(vogl::vector<const GLcharARB *> in_shader_vec, vogl::vector<GLint> lengths); // We'll internally fold this into a single string
+    void set_shader(GLuint id, vogl::vector<const GLcharARB *> in_shader_vec, vogl::vector<GLint> lengths); // We'll internally fold this into a single string
     void set_shader(const GLchar* in_shader_str, int len)
     {
+        m_in_shader.set(in_shader_str, len);
+        m_in_length = len;
+    }
+    void set_shader(GLuint id, const GLchar* in_shader_str, int len)
+    {
+        m_shader_id = id;
         m_in_shader.set(in_shader_str, len);
         m_in_length = len;
     }
@@ -63,7 +69,11 @@ public:
     }
     void set_pp_opts(const dynamic_string &pp_opts)
     {
-        m_pp_opts = pp_opts;
+        m_pp_opts = _check_opts(pp_opts);
+    }
+    void set_pp_prefix(const dynamic_string &pp_prefix)
+    {
+        m_pp_prefix = pp_prefix;
     }
     GLsizei get_count() const
     {
@@ -85,6 +95,28 @@ public:
     {
         return m_time_to_run_pp;
     }
+    void set_null(bool null_value)
+    {
+        m_null = null_value;
+    }
+    // Trace ID for a shader.  If NULL shader set and shader_id set to non-zero,
+    //   PP will only run for specified shaderID, which will be NULL'd out.
+    void set_shader_id(GLuint id)
+    {
+        m_shader_id = id;
+    }
+    void enable_null()
+    {
+        m_null = true;
+    }
+    void enable_null(float* null_color)
+    {
+        m_null = true;
+        m_null_color[0] = null_color[0];
+        m_null_color[1] = null_color[1];
+        m_null_color[2] = null_color[2];
+        m_null_color[3] = null_color[3];
+    }
 
 private:
     static void cleanup();
@@ -93,16 +125,23 @@ private:
     vogl_fs_preprocessor(const vogl_fs_preprocessor&);
     vogl_fs_preprocessor& operator=(const vogl_fs_preprocessor&);
     bool _run();
+    dynamic_string _check_opts(const dynamic_string &in_opts); // set internal state
+    dynamic_string _set_null_output_color(dynamic_string in_shader);
 
     static vogl_fs_preprocessor* m_instance;
     
     dynamic_string m_pp_cmd;
     dynamic_string m_pp_opts;
+    dynamic_string m_pp_prefix;
     GLsizei m_count;
     GLint m_length;
     GLint m_in_length;
+    GLuint m_shader_id;
+    GLuint m_null_shader_id;
     dynamic_string m_in_shader;
     dynamic_string m_output_shader;
+    bool m_null;
+    float m_null_color[4];
     timer m_tm;
     double m_time_to_run_pp;
     bool m_enabled; // is pp enabled?

--- a/src/voglcommon/vogl_gl_replayer.cpp
+++ b/src/voglcommon/vogl_gl_replayer.cpp
@@ -3632,7 +3632,7 @@ vogl_gl_replayer::status_t vogl_gl_replayer::handle_ShaderSource(GLhandleARB tra
         {
             // Assuming that m_fs_pp class was instantiated when this class was and that it already has pp cmd & option info
             // TODO : Need to handle the case where count != 1
-            m_fs_pp->set_shader(strings, lengths);
+            m_fs_pp->set_shader(static_cast<GLuint>(trace_object), strings, lengths);
             if (m_fs_pp->run())
             {
                 count = m_fs_pp->get_count();

--- a/src/voglcommon/vogl_gl_replayer.h
+++ b/src/voglcommon/vogl_gl_replayer.h
@@ -174,12 +174,14 @@ public:
     {
         m_fs_pp->set_pp(str);
     }
-    
     void set_fs_preprocessor_options(const dynamic_string &str)
     {
         m_fs_pp->set_pp_opts(str);
     }
-    
+    void set_fs_preprocessor_prefix(const dynamic_string &str)
+    {
+        m_fs_pp->set_pp_prefix(str);
+    }
     double get_fs_pp_time() const
     {
         return m_fs_pp->get_pp_time();

--- a/src/voglcommon/vogl_shader_state.cpp
+++ b/src/voglcommon/vogl_shader_state.cpp
@@ -184,7 +184,7 @@ bool vogl_shader_state::restore(const vogl_context_info &context_info, vogl_hand
         // Assuming that m_fs_pp class was instantiated when this class was and that it already has pp cmd & option info
         if ((GL_FRAGMENT_SHADER == m_shader_type) && m_fs_pp->enabled())
         {
-            m_fs_pp->set_shader(pStr, m_source.get_len());
+            m_fs_pp->set_shader(m_snapshot_handle, pStr, m_source.get_len());
             if (!m_fs_pp->run())
                 return false;
 

--- a/src/vogleditor/vogleditor_tracereplayer.cpp
+++ b/src/vogleditor/vogleditor_tracereplayer.cpp
@@ -284,9 +284,10 @@ vogleditor_tracereplayer_result vogleditor_traceReplayer::replay(vogl_trace_file
        m_pTraceReplayer->set_fs_preprocessor(m_fs_preprocessor.c_str());
        // Only check FSpp options when FS preprocessor is enabled
        if (m_fs_preprocessor_options.size() > 0)
-       {
           m_pTraceReplayer->set_fs_preprocessor_options(m_fs_preprocessor_options.c_str());
-       }
+
+       if (m_fs_preprocessor_prefix.size() > 0)
+           m_pTraceReplayer->set_fs_preprocessor_prefix(m_fs_preprocessor_prefix.c_str());
    }
 
    if (!m_pTraceReplayer->init(replayer_flags, &m_window, m_pTraceReader->get_sof_packet(), m_pTraceReader->get_multi_blob_manager()))

--- a/src/vogleditor/vogleditor_tracereplayer.h
+++ b/src/vogleditor/vogleditor_tracereplayer.h
@@ -47,6 +47,7 @@ private:
     std::string m_screenshot_prefix;
     std::string m_fs_preprocessor;
     std::string m_fs_preprocessor_options;
+    std::string m_fs_preprocessor_prefix;
 };
 
 #endif // VOGLEDITOR_TRACEREPLAYER_H

--- a/src/voglreplay/replay_tool_replay.cpp
+++ b/src/voglreplay/replay_tool_replay.cpp
@@ -105,6 +105,7 @@ static command_line_param_desc g_command_line_param_descs_replay[] =
     { "swap_sleep", 1, false, "Replay: Sleep for X milliseconds after every swap" },
     { "fs_preprocessor", 1, false, "Replay: Run all FS through specified pre-processor prior to glCreateShader() call and substitute the shader output by the pre-processor into the glCreateShader() call." },
     { "fs_preprocessor_options", 1, false, "Replay: Options to pass to the FS pre-processor.  Must also specify --fs_preprocessor" },
+    { "fs_preprocessor_prefix", 1, false, "Replay: Dir/prefix to append to FS input to PP and output from PP.  Must also specify --fs_preprocessor" },
 };
 
 static const struct
@@ -1337,6 +1338,12 @@ static int do_non_interactive_mode(replay_data_t &rdata)
             double loop_time = time_since_start - time_looping_started;
             unsigned int loop_frames = (rdata.snapshot_loop_end_frame - rdata.snapshot_loop_start_frame) * num_loops;
 
+            if (rdata.replayer.get_flags() & cGLReplayerFSPreprocessor)
+            {
+                double fs_pp_time = rdata.replayer.get_fs_pp_time();
+                vogl_printf("Ran with FS Preprocessor (FSPP) enabled:\n");
+                vogl_printf("FSPP Time: %.3f secs\n", fs_pp_time);
+            }
             unsigned int initial_frames = replayer.get_total_swaps() - loop_frames;
             vogl_printf("Initial: %u total swaps, %.3f secs, %3.3f avg fps\n", initial_frames, time_looping_started, initial_frames / time_looping_started);
             vogl_printf("Looping: %u total swaps, %.3f secs, %3.3f avg fps\n", loop_frames, loop_time, loop_frames / loop_time);
@@ -1465,6 +1472,7 @@ bool tool_replay_mode(vogl::vector<command_line_param_desc> *desc)
     
     rdata.replayer.set_fs_preprocessor(g_command_line_params().get_value_as_string("fs_preprocessor", 0, ""));
     rdata.replayer.set_fs_preprocessor_options(g_command_line_params().get_value_as_string("fs_preprocessor_options", 0, ""));
+    rdata.replayer.set_fs_preprocessor_prefix(g_command_line_params().get_value_as_string("fs_preprocessor_prefix", 0, ""));
 
     if (!rdata.keyframe_base_filename.is_empty())
     {


### PR DESCRIPTION
Aded "vogl_analysis.py" script that can be used for frame performance analysis using NULL FS substitution.

Added NULL_FS capability to FS PP.  Currently this option is given on the vogl cmd line via the "--fs_preprocessor_options <opts>" arg and then consumed by FS PP before passing any remaining options to FS PP.  Basic syntax is "NULL_FS[ID#]:r,g,b,a" where optional [ID#] will only NULL a single FS, and optional r,g,b,a floats will use color other than default purple.
