### PR TITLE
State render groups settings

### DIFF
--- a/src/voglcommon/vogl_gl_utils.cpp
+++ b/src/voglcommon/vogl_gl_utils.cpp
@@ -1058,12 +1058,11 @@ bool vogl_is_start_nested_entrypoint(gl_entrypoint_id_t id)
     switch (id)
     {
         case VOGL_ENTRYPOINT_glBegin:
-            // TODO: Add after control is added to settings dialog
-            //      case VOGL_ENTRYPOINT_glPushMatrix:
-            //      case VOGL_ENTRYPOINT_glPushAttrib:
-            //      case VOGL_ENTRYPOINT_glPushClientAttrib:
-            //      case VOGL_ENTRYPOINT_glPushName:
-            //      case VOGL_ENTRYPOINT_glNewList:
+        case VOGL_ENTRYPOINT_glNewList:
+        case VOGL_ENTRYPOINT_glPushName:
+        case VOGL_ENTRYPOINT_glPushMatrix:
+        case VOGL_ENTRYPOINT_glPushAttrib:
+        case VOGL_ENTRYPOINT_glPushClientAttrib:
             return true;
         default:
             break;
@@ -1079,12 +1078,11 @@ bool vogl_is_end_nested_entrypoint(gl_entrypoint_id_t id)
     switch (id)
     {
         case VOGL_ENTRYPOINT_glEnd:
-            // TODO: Add after control is added to settings dialog
-            //      case VOGL_ENTRYPOINT_glPopMatrix:
-            //      case VOGL_ENTRYPOINT_glPopAttrib:
-            //      case VOGL_ENTRYPOINT_glPopClientAttrib:
-            //      case VOGL_ENTRYPOINT_glPopName:
-            //      case VOGL_ENTRYPOINT_glEndList:
+        case VOGL_ENTRYPOINT_glEndList:
+        case VOGL_ENTRYPOINT_glPopName:
+        case VOGL_ENTRYPOINT_glPopMatrix:
+        case VOGL_ENTRYPOINT_glPopAttrib:
+        case VOGL_ENTRYPOINT_glPopClientAttrib:
             return true;
         default:
             break;

--- a/src/vogleditor/vogleditor.cpp
+++ b/src/vogleditor/vogleditor.cpp
@@ -860,6 +860,12 @@ void VoglEditor::on_actionEdit_triggered()
     if (code == QDialog::Accepted)
     {
         dialog.save(g_SETTINGS_FILE);
+        // if groups changed update tree display
+        if (dialog.groupOptionsChanged())
+        {
+            g_settings.update_group_active_lists();
+            resetApiCallTreeModel();
+        }
     }
 }
 
@@ -1757,6 +1763,16 @@ bool VoglEditor::open_trace_file(dynamic_string filename)
     vogleditor_output_message("...success!");
 
     this->setCursor(origCursor);
+    return true;
+}
+
+bool VoglEditor::resetApiCallTreeModel()
+{
+    dynamic_string filename(m_openFilename.toLocal8Bit().data());
+
+    on_action_Close_triggered();
+    pre_open_trace_file(filename);
+
     return true;
 }
 

--- a/src/vogleditor/vogleditor.h
+++ b/src/vogleditor/vogleditor.h
@@ -145,6 +145,7 @@ private:
     void displayProgramArb(GLuint64 programArbHandle, bool bBringTabToFront);
     void displayProgram(GLuint64 programHandle, bool bBringTabToFront);
     bool displayBuffer(GLuint64 bufferHandle, bool bBringTabToFront);
+    bool resetApiCallTreeModel();
 
     bool launch_application_to_generate_trace(const QString &cmdLine, const QProcessEnvironment &environment);
 

--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -161,7 +161,7 @@ bool vogleditor_apiCallTreeItem::isApiCall() const
 }
 bool vogleditor_apiCallTreeItem::isGroup() const
 {
-    return (g_settings.groups_state_render() && (m_pGroupItem != NULL));
+    return (g_settings.group_state_render_stat() && (m_pGroupItem != NULL));
 }
 bool vogleditor_apiCallTreeItem::isFrame() const
 {

--- a/src/vogleditor/vogleditor_qapicalltreemodel.h
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.h
@@ -97,6 +97,9 @@ private:
     bool isEndNestedEntrypoint(gl_entrypoint_id_t id) const;
     bool isFrameBufferWriteEntrypoint(gl_entrypoint_id_t id) const;
 
+    bool displayMarkerTextAsLabel() const;
+    bool hideMarkerPopApiCall() const;
+
 private:
     vogleditor_apiCallTreeItem *m_rootItem;
     vogl_ctypes *m_pTrace_ctypes;

--- a/src/vogleditor/vogleditor_qsettingsdialog.cpp
+++ b/src/vogleditor/vogleditor_qsettingsdialog.cpp
@@ -9,14 +9,286 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
 {
     ui->setupUi(this);
 
+    // (TODO?: connect signals to g_settings)
+
+    // tab parent
+    ui->tabWidget->setCurrentIndex(g_settings.tab_page());
+
+    connect(ui->tabWidget, SIGNAL(currentChanged(int)),
+            SLOT(tabCB(int)));
+
+    connect(ui->buttonBox, SIGNAL(rejected()), SLOT(cancelCB()));
+
+    // Startup settings tab
     QString strSettings = g_settings.to_string();
 
     ui->textEdit->setText(strSettings);
-}
+
+    // Group settings tab
+
+    // State Render
+    ui->checkboxStateRender->setText(g_settings.group_state_render_name());
+    ui->checkboxStateRender->setChecked(g_settings.group_state_render_stat());
+    ui->checkboxStateRender->setEnabled(g_settings.group_state_render_used());
+
+    connect(ui->checkboxStateRender, SIGNAL(stateChanged(int)),
+            //SLOT(checkboxCB(int)));
+            SLOT(checkboxStateRenderCB(int)));
+
+    // Debug markers
+    QVector<QCheckBox *> checkboxList;
+
+    QStringList group_debug_marker_names = g_settings.group_debug_marker_names();
+    QVector<bool> debug_marker_stat = g_settings.group_debug_marker_stat();
+    QVector<bool> debug_marker_used = g_settings.group_debug_marker_used();
+    int debug_marker_cnt = group_debug_marker_names.size();
+    for (int i = 0; i < debug_marker_cnt; i++)
+    {
+        checkboxList << new QCheckBox(group_debug_marker_names[i], ui->groupboxDebugMarker);
+        checkboxList[i]->setChecked(debug_marker_stat[i]);
+        checkboxList[i]->setEnabled(debug_marker_used[i]);
+        ui->vLayout_groupboxDebugMarker->insertWidget(i, checkboxList[i]);
+    }
+
+    for (int i = 0; i < debug_marker_cnt; i++)
+    {
+        connect(checkboxList[i], SIGNAL(stateChanged(int)),
+                SLOT(checkboxCB(int)));
+    }
+
+    // Debug marker options
+    ui->radiobuttonDebugMarkerNameOption->setText(g_settings.group_debug_marker_option_name_label());
+    ui->radiobuttonDebugMarkerNameOption->setChecked(g_settings.group_debug_marker_option_name_stat());
+
+    ui->radiobuttonDebugMarkerOmitOption->setText(g_settings.group_debug_marker_option_omit_label());
+    ui->radiobuttonDebugMarkerOmitOption->setChecked(g_settings.group_debug_marker_option_omit_stat());
+
+    setEnableDebugMarkerOptions();
+
+    connect(ui->radiobuttonDebugMarkerNameOption, SIGNAL(toggled(bool)),
+            SLOT(radiobuttonNameCB(bool)));
+    connect(ui->radiobuttonDebugMarkerOmitOption, SIGNAL(toggled(bool)),
+            SLOT(radiobuttonOmitCB(bool)));
+
+    // Nest options
+    checkboxList.clear();
+
+    // Groupbox
+    ui->groupboxNestOptions->setTitle(g_settings.groupbox_nest_options_name());
+    ui->groupboxNestOptions->setChecked(g_settings.groupbox_nest_options_stat());
+    ui->groupboxNestOptions->setEnabled(g_settings.groupbox_nest_options_used());
+    if (g_settings.groupbox_nest_options_stat())
+    {
+        // For now, toggle State/Render groups and Nest options
+        checkboxStateRenderCB(false);
+    }
+
+    // Checkboxes
+    QStringList group_nest_options_names = g_settings.group_nest_options_names();
+    QVector<bool> nest_options_stat = g_settings.group_nest_options_stat();
+    QVector<bool> nest_options_used = g_settings.group_nest_options_used();
+    int nest_options_cnt = group_nest_options_names.size();
+    for (int i = 0; i < nest_options_cnt; i++)
+    {
+        checkboxList << new QCheckBox(group_nest_options_names[i], ui->groupboxNestOptions);
+        checkboxList[i]->setChecked(nest_options_stat[i]);
+        checkboxList[i]->setEnabled(nest_options_used[i]);
+        ui->vLayout_groupboxNestOptionsScrollarea->addWidget(checkboxList[i]);
+    }
+
+    connect(ui->groupboxNestOptions, SIGNAL(toggled(bool)), // groupbox
+            SLOT(groupboxNestOptionsCB(bool)));
+
+    for (int i = 0; i < nest_options_cnt; i++) // checkboxes in groupbox
+    {
+        connect(checkboxList[i], SIGNAL(stateChanged(int)),
+                SLOT(checkboxCB(int)));
+    }
+
+    // Save initial state
+    m_bGroupInitialState = groupState();
+
+} // constructor
 
 vogleditor_QSettingsDialog::~vogleditor_QSettingsDialog()
 {
     delete ui;
+    clearLayout(ui->verticalLayout_tabGroups);
+
+} // destructor
+
+void vogleditor_QSettingsDialog::clearLayout(QLayout *layout)
+{
+    // taken from
+    // http://stackoverflow.com/questions/4272196/qt-remove-all-widgets-from-layout
+    // ... didn't seem to make any difference using valgrind Memcheck...
+
+    while (QLayoutItem *item = layout->takeAt(0))
+    {
+        delete item->widget();
+        if (QLayout *childLayout = item->layout())
+            clearLayout(childLayout);
+        delete item;
+    }
+} // clearLayout
+
+void vogleditor_QSettingsDialog::tabCB(int page)
+{
+    g_settings.set_tab_page(page);
+}
+
+void vogleditor_QSettingsDialog::checkboxStateRenderCB(int val)
+{
+    bool bVal = bool(val);
+    if (bVal)
+    {
+        ui->groupboxNestOptions->setChecked(!bVal);
+        g_settings.set_groupbox_nest_options_stat(!bVal);
+    }
+    // Update
+    g_settings.set_group_state_render_stat(bVal);
+    updateTextTab();
+
+} // checkboxStateRenderCB
+
+void vogleditor_QSettingsDialog::groupboxNestOptionsCB(bool bVal)
+{
+    if (bVal)
+    {
+        ui->checkboxStateRender->setChecked(!bVal);
+        g_settings.set_group_state_render_stat(!bVal);
+    }
+    // Update
+    g_settings.set_groupbox_nest_options_stat(bVal);
+    updateTextTab();
+
+} // groupboxNestOptionsCB
+
+void vogleditor_QSettingsDialog::checkboxCB(int state)
+{
+    g_settings.set_group_state_render_stat(ui->checkboxStateRender->isChecked());
+    g_settings.set_group_debug_marker_stat(checkboxValues(ui->groupboxDebugMarker));
+    g_settings.set_group_nest_options_stat(checkboxValues(ui->groupboxNestOptions));
+
+    setEnableDebugMarkerOptions();
+
+    updateTextTab();
+
+} // checkboxCB
+
+void vogleditor_QSettingsDialog::setEnableDebugMarkerOptions()
+{
+    //  Disable options if no Debug marker groups are checked
+    QVector<bool> bCurrentState = checkboxValues(ui->groupboxDebugMarker);
+
+    bool bVal;
+    foreach(bVal, bCurrentState)
+    {
+        if (bVal)
+            break;
+    }
+    enableDebugMarkerOptions(bVal);
+}
+void vogleditor_QSettingsDialog::enableDebugMarkerOptions(bool bVal)
+{
+    ui->radiobuttonDebugMarkerNameOption->setEnabled(bVal);
+    ui->radiobuttonDebugMarkerOmitOption->setEnabled(bVal);
+
+    // Notify g_settings
+    g_settings.set_group_debug_marker_option_name_used(bVal);
+    g_settings.set_group_debug_marker_option_omit_used(bVal);
+}
+
+void vogleditor_QSettingsDialog::radiobuttonNameCB(bool state)
+{
+    g_settings.set_group_debug_marker_option_name_stat(state);
+    updateTextTab();
+}
+
+void vogleditor_QSettingsDialog::radiobuttonOmitCB(bool state)
+{
+    g_settings.set_group_debug_marker_option_omit_stat(state);
+    updateTextTab();
+}
+
+void vogleditor_QSettingsDialog::updateTextTab()
+{
+    //update json tab settings page
+    QString strSettings = g_settings.to_string();
+    ui->textEdit->setText(strSettings);
+}
+
+QVector<bool> vogleditor_QSettingsDialog::checkboxValues(QObject *widget)
+{
+    // Note: This function is intended to only return checkbox values of
+    //       API call names, so for the Debug marker API call list parent
+    //       radiobuttons were used for the options.
+    QList<QCheckBox *> groupCheckBoxes = widget->findChildren<QCheckBox *>();
+
+    QVector<bool> bQVector;
+    QList<QCheckBox *>::const_iterator iter = groupCheckBoxes.begin();
+
+    while (iter != groupCheckBoxes.end())
+    {
+        bQVector << (*iter)->isChecked();
+        iter++;
+    }
+    return bQVector;
+
+} // checkboxValues()
+
+QVector<bool> vogleditor_QSettingsDialog::groupState()
+{
+    QVector<bool> bCurrentState;
+
+    bCurrentState << ui->checkboxStateRender->isChecked();
+    bCurrentState << ui->groupboxNestOptions->isChecked();
+
+    bCurrentState << checkboxValues(ui->groupboxDebugMarker);
+    bCurrentState << checkboxValues(ui->groupboxNestOptions);
+
+    bCurrentState << ui->radiobuttonDebugMarkerNameOption->isChecked();
+    bCurrentState << ui->radiobuttonDebugMarkerOmitOption->isChecked();
+
+    return bCurrentState;
+
+} // groupState
+
+void vogleditor_QSettingsDialog::reset()
+{
+    // Set in same order as saved in ::groupState()
+    //
+    // TODO: QMap these, widget key to value, in constructor
+    //       so order won't matter
+    int i = 0;
+    ui->checkboxStateRender->setChecked(m_bGroupInitialState[i++]);
+
+    ui->groupboxNestOptions->setChecked(m_bGroupInitialState[i++]);
+
+    QList<QCheckBox *> checkboxes = ui->groupboxDebugMarker->findChildren<QCheckBox *>();
+    for (int indx = 0; indx < checkboxes.count(); indx++)
+    {
+        checkboxes[indx]->setChecked(m_bGroupInitialState[i++]);
+    }
+    checkboxes = ui->groupboxNestOptions->findChildren<QCheckBox *>();
+    for (int indx = 0; indx < checkboxes.count(); indx++)
+    {
+        checkboxes[indx]->setChecked(m_bGroupInitialState[i++]);
+    }
+
+    ui->radiobuttonDebugMarkerNameOption->setChecked(m_bGroupInitialState[i++]);
+    ui->radiobuttonDebugMarkerOmitOption->setChecked(m_bGroupInitialState[i++]);
+
+} // reset
+
+bool vogleditor_QSettingsDialog::groupOptionsChanged()
+{
+    return m_bGroupInitialState != groupState();
+}
+
+void vogleditor_QSettingsDialog::cancelCB()
+{
+    reset();
 }
 
 void vogleditor_QSettingsDialog::save(const char *settingsFile)

--- a/src/vogleditor/vogleditor_qsettingsdialog.h
+++ b/src/vogleditor/vogleditor_qsettingsdialog.h
@@ -16,10 +16,32 @@ public:
     explicit vogleditor_QSettingsDialog(QWidget *parent = 0);
     ~vogleditor_QSettingsDialog();
 
+    bool groupOptionsChanged();
     void save(const char *settingsFile);
+
+private
+slots:
+    void tabCB(int);
+    void checkboxStateRenderCB(int);
+    void checkboxCB(int);
+    void groupboxNestOptionsCB(bool);
+    void radiobuttonNameCB(bool);
+    void radiobuttonOmitCB(bool);
+    void cancelCB();
+
+private:
+    QVector<bool> checkboxValues(QObject *);
+    QVector<bool> groupState();
+    void updateTextTab();
+    void clearLayout(QLayout *);
+    void setEnableDebugMarkerOptions();
+    void enableDebugMarkerOptions(bool);
+    void reset();
 
 private:
     Ui::vogleditor_QSettingsDialog *ui;
+
+    QVector<bool> m_bGroupInitialState;
 };
 
 #endif // VOGLEDITOR_QSETTINGSDIALOG_H

--- a/src/vogleditor/vogleditor_qsettingsdialog.ui
+++ b/src/vogleditor/vogleditor_qsettingsdialog.ui
@@ -15,7 +15,106 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTextEdit" name="textEdit"/>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Startup</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QTextEdit" name="textEdit"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabGroups">
+      <attribute name="title">
+       <string>Groups</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_tabGroups">
+       <item>
+        <widget class="QCheckBox" name="checkboxStateRender">
+         <property name="text">
+          <string>State/Render groups</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupboxDebugMarker">
+         <property name="title">
+          <string>Debug marker groups</string>
+         </property>
+         <layout class="QVBoxLayout" name="vLayout_groupboxDebugMarker">
+          <item>
+           <widget class="QFrame" name="frame">
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <item>
+              <widget class="QRadioButton" name="radiobuttonDebugMarkerNameOption">
+               <property name="text">
+                <string>Use text argument as label</string>
+               </property>
+               <property name="autoExclusive">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radiobuttonDebugMarkerOmitOption">
+               <property name="text">
+                <string>Hide terminating API call</string>
+               </property>
+               <property name="autoExclusive">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupboxNestOptions">
+         <property name="title">
+          <string>Nest options</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <layout class="QVBoxLayout" name="vLayout_groupboxNestOptions">
+          <item>
+           <widget class="QScrollArea" name="scrollArea">
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>334</width>
+               <height>87</height>
+              </rect>
+             </property>
+             <layout class="QVBoxLayout" name="vLayout_groupboxNestOptionsScrollarea"/>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -29,6 +128,7 @@
    </item>
   </layout>
  </widget>
+ <layoutdefault spacing="6" margin="11"/>
  <resources/>
  <connections>
   <connection>

--- a/src/vogleditor/vogleditor_settings.h
+++ b/src/vogleditor/vogleditor_settings.h
@@ -3,22 +3,45 @@
 
 #include "vogl_dynamic_string.h"
 #include "vogl_json.h"
-#include <QString>
+#include <QStringList>
+#include <QVector>
 
 class vogleditor_settings;
 extern vogleditor_settings g_settings;
 
 struct vogleditor_setting_struct
 {
+    int tab_page;
+
     int window_position_left;
     int window_position_top;
     int window_size_width;
     int window_size_height;
     unsigned int trim_large_trace_prompt_size;
 
-    bool groups_state_render;
-    bool groups_push_pop_markers;
-    bool groups_nested_calls;
+    QString state_render_name;
+    QStringList state_render_nest_list;
+    bool state_render_stat;
+    bool state_render_used;
+
+    QStringList debug_marker_list;
+    QVector<bool> debug_marker_stat;
+    QVector<bool> debug_marker_used;
+
+    QString debug_marker_option_name_labl;
+    bool debug_marker_option_name_stat;
+    bool debug_marker_option_name_used;
+
+    QString debug_marker_option_omit_labl;
+    bool debug_marker_option_omit_stat;
+    bool debug_marker_option_omit_used;
+
+    QString groupbox_nest_options_name;
+    bool groupbox_nest_options_stat;
+    bool groupbox_nest_options_used;
+    QStringList nest_options_list;
+    QVector<bool> nest_options_stat;
+    QVector<bool> nest_options_used;
 };
 
 class vogleditor_settings
@@ -35,6 +58,16 @@ public:
     QString to_string();
     bool from_string(const char *settingsStr);
 
+    int tab_page()
+    {
+        return m_settings.tab_page;
+    }
+    void set_tab_page(int page)
+    {
+        m_settings.tab_page = page;
+    }
+
+    // Startup
     int window_position_left()
     {
         return m_settings.window_position_left;
@@ -77,35 +110,201 @@ public:
         m_settings.trim_large_trace_prompt_size = trim_large_trace_prompt_size;
     }
 
-    bool groups_state_render()
+    // Groups
+
+    // State/Render
+    QString group_state_render_name()
     {
-        return m_settings.groups_state_render;
+        return m_settings.state_render_name;
     }
-    bool groups_push_pop_markers()
+    bool group_state_render_stat()
     {
-        return m_settings.groups_push_pop_markers;
+        return m_settings.state_render_stat;
     }
-    bool groups_nested_calls()
+    void set_group_state_render_stat(bool state_render_stat)
     {
-        return m_settings.groups_nested_calls;
+        m_settings.state_render_stat = state_render_stat;
     }
-    void set_groups_state_render(bool groups_state_render)
+    bool group_state_render_used()
     {
-        m_settings.groups_state_render = groups_state_render;
+        return m_settings.state_render_used;
     }
-    void set_groups_push_pop_markers(bool groups_push_pop_markers)
+
+    // Debug marker
+    QStringList group_debug_marker_names()
     {
-        m_settings.groups_push_pop_markers = groups_push_pop_markers;
+        return m_settings.debug_marker_list;
     }
-    void set_groups_nested_calls(bool groups_nested_calls)
+
+    QVector<bool> group_debug_marker_stat()
     {
-        m_settings.groups_nested_calls = groups_nested_calls;
+        return m_settings.debug_marker_stat;
+    }
+    void set_group_debug_marker_stat(QVector<bool> debug_marker_stat)
+    {
+        m_settings.debug_marker_stat = debug_marker_stat;
+    }
+
+    QVector<bool> group_debug_marker_used()
+    {
+        return m_settings.debug_marker_used;
+    }
+    void set_group_debug_marker_used(QVector<bool> debug_marker_used)
+    {
+        m_settings.debug_marker_used = debug_marker_used;
+    }
+
+    QString group_debug_marker_option_name_label()
+    {
+        return m_settings.debug_marker_option_name_labl;
+    }
+    bool group_debug_marker_option_name_stat()
+    {
+        return m_settings.debug_marker_option_name_stat;
+    }
+    bool group_debug_marker_option_name_used()
+    {
+        return m_settings.debug_marker_option_name_used;
+    }
+
+    QString group_debug_marker_option_omit_label()
+    {
+        return m_settings.debug_marker_option_omit_labl;
+    }
+    bool group_debug_marker_option_omit_stat()
+    {
+        return m_settings.debug_marker_option_omit_stat;
+    }
+    bool group_debug_marker_option_omit_used()
+    {
+        return m_settings.debug_marker_option_omit_used;
+    }
+
+    void set_group_debug_marker_option_name_stat(bool stat)
+    {
+        m_settings.debug_marker_option_name_stat = stat;
+    }
+    void set_group_debug_marker_option_name_used(bool used)
+    {
+        m_settings.debug_marker_option_name_used = used;
+    }
+    void set_group_debug_marker_option_omit_stat(bool stat)
+    {
+        m_settings.debug_marker_option_omit_stat = stat;
+    }
+    void set_group_debug_marker_option_omit_used(bool used)
+    {
+        m_settings.debug_marker_option_omit_used = used;
+    }
+
+    // Nest options
+
+    // Groupbox
+    QString groupbox_nest_options_name()
+    {
+        return m_settings.groupbox_nest_options_name;
+    }
+    bool groupbox_nest_options_stat()
+    {
+        return m_settings.groupbox_nest_options_stat;
+    }
+    void set_groupbox_nest_options_stat(bool b_val)
+    {
+        m_settings.groupbox_nest_options_stat = b_val;
+    }
+    bool groupbox_nest_options_used()
+    {
+        return m_settings.groupbox_nest_options_used;
+    }
+
+    // Checkboxes
+    QStringList group_nest_options_names()
+    {
+        return m_settings.nest_options_list;
+    }
+    QVector<bool> group_nest_options_stat()
+    {
+        return m_settings.nest_options_stat;
+    }
+    void set_group_nest_options_stat(QVector<bool> nest_options_stat)
+    {
+        m_settings.nest_options_stat = nest_options_stat;
+    }
+    QVector<bool> group_nest_options_used()
+    {
+        return m_settings.nest_options_used;
+    }
+    void set_group_nest_options_used(QVector<bool> nest_options_used)
+    {
+        m_settings.nest_options_used = nest_options_used;
+    }
+
+    void update_group_active_lists()
+    {
+        m_active_debug_marker = active_debug_marker();
+        m_active_nest_options = active_nest_options();
+    }
+
+    bool is_active_state_render_nest(QString str)
+    {
+        // Use allowed nest calls with State/Render groups if selected under
+        // Nest options (even though nest call item is disabled)
+        return m_active_state_render_nest.contains(str) && m_settings.state_render_stat && m_active_nest_options.contains(str);
+    }
+    bool is_active_debug_marker(QString str)
+    {
+        return m_active_debug_marker.contains(str);
+    }
+    bool is_active_nest_options(QString str)
+    {
+        return m_settings.groupbox_nest_options_stat && m_active_nest_options.contains(str);
+    }
+
+private:
+    const QStringList active_state_render_nest() const
+    {
+        QStringList activeList;
+        for (int i = 0; i < m_settings.state_render_nest_list.count(); i++)
+        {
+            activeList << m_settings.state_render_nest_list[i].split("/");
+        }
+        return activeList;
+    }
+    const QStringList active_debug_marker() const
+    {
+
+        QStringList activeList;
+        for (int i = 0; i < m_settings.debug_marker_list.count(); i++)
+        {
+            if (m_settings.debug_marker_stat[i])
+            {
+                activeList << m_settings.debug_marker_list[i].split("/");
+            }
+        }
+        return activeList;
+    }
+    const QStringList active_nest_options() const
+    {
+
+        QStringList activeList;
+        for (int i = 0; i < m_settings.nest_options_list.count(); i++)
+        {
+            if (m_settings.nest_options_stat[i])
+            {
+                activeList << m_settings.nest_options_list[i].split("/");
+            }
+        }
+        return activeList;
     }
 
 private:
     unsigned int m_file_format_version;
     vogleditor_setting_struct m_settings;
     vogleditor_setting_struct m_defaults;
+
+    QStringList m_active_state_render_nest;
+    QStringList m_active_debug_marker;
+    QStringList m_active_nest_options;
 
     vogl::dynamic_string get_settings_path(const char *settingsFilename);
     bool to_json(vogl::json_document &doc);


### PR DESCRIPTION
Add tabs and groups to the settings dialog

In the groups tab:
- Add selectable options to nest apicalls
- Add display controls for Debug marker groups
- Update tree display dynamically

The default is the current tree display and won't look any different

This addresses item 1) from issue #161

> 1) Add a way to toggle between modes so that users can easily just see the draw calls without other clutter and clicking - perhaps a combo box so that we can easily add more hierarchy methods without consuming too much toolbar space?

Except instead of using comboboxes, use checkboxes in a scrollable groupbox
![vogl-group-settingsa png](https://cloud.githubusercontent.com/assets/6090880/5056387/754bb718-6c36-11e4-93bd-d835d28a5206.png)
