### PR TITLE
UI: move some logic to constructors

### DIFF
--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -76,6 +76,8 @@ vogleditor_apiCallTreeItem::vogleditor_apiCallTreeItem(vogleditor_frameItem *fra
     {
         m_pModel = m_parentItem->m_pModel;
     }
+
+    parent->appendChild(this);
 }
 
 // Constructor for group nodes
@@ -92,6 +94,8 @@ vogleditor_apiCallTreeItem::vogleditor_apiCallTreeItem(vogleditor_groupItem *gro
     {
         m_pModel = m_parentItem->m_pModel;
     }
+
+    parent->appendChild(this);
 }
 
 // Constructor for apiCall nodes
@@ -120,6 +124,8 @@ vogleditor_apiCallTreeItem::vogleditor_apiCallTreeItem(vogleditor_apiCallItem *a
     {
         m_pModel = m_parentItem->m_pModel;
     }
+
+    parent->appendChild(this);
 }
 
 vogleditor_apiCallTreeItem::~vogleditor_apiCallTreeItem()

--- a/src/vogleditor/vogleditor_groupitem.h
+++ b/src/vogleditor/vogleditor_groupitem.h
@@ -29,7 +29,7 @@
 #include "vogleditor_snapshotitem.h"
 #include "vogleditor_apicallitem.h"
 
-class vogleditor_frameItem;
+#include "vogleditor_frameitem.h"
 
 class vogleditor_groupItem : public vogleditor_snapshotItem
 {
@@ -37,6 +37,7 @@ public:
     vogleditor_groupItem(vogleditor_frameItem *pFrameItem)
         : m_pParentFrame(pFrameItem)
     {
+        pFrameItem->appendGroup(this);
     }
 
     ~vogleditor_groupItem()

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -202,7 +202,6 @@ bool vogleditor_QApiCallTreeModel::init(vogl_trace_file_reader *pTrace_reader)
             {
                 pCurFrame = vogl_new(vogleditor_frameItem, total_swaps);
                 vogleditor_apiCallTreeItem *pNewFrameNode = vogl_new(vogleditor_apiCallTreeItem, pCurFrame, pParentRoot);
-                pParentRoot->appendChild(pNewFrameNode);
                 m_itemList.append(pNewFrameNode);
 
                 if (pPendingSnapshot != NULL)
@@ -310,7 +309,6 @@ bool vogleditor_QApiCallTreeModel::init(vogl_trace_file_reader *pTrace_reader)
 
                 // make tree item for the apicall
                 item = vogl_new(vogleditor_apiCallTreeItem, pCallItem, pCurParent);
-                pCurParent->appendChild(item);
                 m_itemList.append(item);
             }
 
@@ -512,25 +510,15 @@ vogleditor_apiCallTreeItem *vogleditor_QApiCallTreeModel::create_group(vogledito
                                                                        vogleditor_groupItem *&pCurGroupObj,
                                                                        vogleditor_apiCallTreeItem *pParentNode)
 {
-    /* Operations:
- *     + create groupItem object
- *       > add groupItem object to current frame's groupItem list
- * 
- *     + create treeItem object (apiCallTreeItem of "group" type)
- *       > add treeItem object to children of parent treeItem 
- *       > add treeItem object to tree model's (this) apiCallItem list
- */
     if (!g_settings.group_state_render_stat())
     {
         return pParentNode;
     }
-    // Make a new group item
+    // Make new group item and add to frame group list
     pCurGroupObj = vogl_new(vogleditor_groupItem, pCurFrameObj);
-    pCurFrameObj->appendGroup(pCurGroupObj); // (move this to constructor?)
 
-    // Make a new (group) tree item and insert into tree
+    // Make a new (group type) apicalltree item and insert into tree
     vogleditor_apiCallTreeItem *pNewGroupNode = vogl_new(vogleditor_apiCallTreeItem, pCurGroupObj, pParentNode);
-    pParentNode->appendChild(pNewGroupNode);
     m_itemList.append(pNewGroupNode);
     return pNewGroupNode;
 }


### PR DESCRIPTION
Some code cleanup while reading through the code:

In creating the apicall tree, the client (vogleditor_QApiCallTreeModel)
creates the calltree objects (vogleditor_apiCallTreeItem objects). If
the object is constructed with a parent then the client must then add
the new object to the child list of the object's parent after the object
has been constructed.

Instead of the client having to know/remember to do this for the object,
it's now done in the object's constructor. This makes for easier
comprehension/reading of the code in my opinion.

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
