### PR TITLE
UI: Color code timeline for groups

### DIFF
--- a/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
@@ -160,15 +160,17 @@ float vogleditor_apiCallTimelineModel::u64ToFloat(uint64_t value)
 
 unsigned int vogleditor_apiCallTimelineModel::randomRGB()
 {
-    unsigned int rgbval = 0;
 
-    for (int i = 0; i < 3; i++)
-    {
-        // mask out some lower bits from each component for more contrast
-        rgbval |= (rand() & 0xF8) << (i * 8);
-    }
+    // TODO: If Debug marker groups are allowed to be colored independent of the
+    //       State/Render groups setting, then force their colors to be a strong
+    //       mix of blue/red and blue/green to distinguish them separately from
+    //       independent apicalls which are a mix of red/green.
+    //static int sSwap = 2;
+    //sSwap = 3 - sSwap;
+    //return  (0xC0 | (0x40 << sSwap * 8) | (rand() & ((0xFF << sSwap * 8) | 0xFF)));
 
-    return rgbval;
+    // mask out some lower bits from each component for greater contrast
+    return (rand() & 0xF8F8F8);
 }
 
 void vogleditor_apiCallTimelineModel::AddApiCallsToTimeline(vogleditor_apiCallTreeItem *pParentCallTreeItem, vogleditor_timelineItem *pParentTimelineItem)

--- a/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
@@ -212,9 +212,18 @@ void vogleditor_apiCallTimelineModel::AddApiCallsToTimeline(vogleditor_apiCallTr
             // Add random color for debug marker group parent
             if (g_settings.group_debug_marker_in_use())
             {
-                if (vogl_is_marker_push_entrypoint(pChildCallTreeItem->apiCallItem()->getTracePacket()->get_entrypoint_id()))
+                // (For now) only if State/Render groups are enabled so that
+                // default timeline display isn't affected (debug marker groups
+                // are checked on)
+                // TODO: remove check for state/render status if/when consensus
+                //       is the debug marker groups should be separately colored
+                //       by default (when checked on)
+                if (g_settings.group_state_render_stat())
                 {
-                    pNewTimelineItem->setBrush(new QBrush(QColor(randomRGB())));
+                    if (vogl_is_marker_push_entrypoint(pChildCallTreeItem->apiCallItem()->getTracePacket()->get_entrypoint_id()))
+                    {
+                        pNewTimelineItem->setBrush(new QBrush(QColor(randomRGB())));
+                    }
                 }
             }
         }

--- a/src/vogleditor/vogleditor_apicalltimelinemodel.h
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.h
@@ -38,6 +38,7 @@ public:
     void refresh();
 
 private:
+    unsigned int randomRGB();
     void AddApiCallsToTimeline(vogleditor_apiCallTreeItem *pRoot, vogleditor_timelineItem *pDestRoot);
     float u64ToFloat(uint64_t value);
 

--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -377,6 +377,7 @@ void vogleditor_apiCallTreeItem::setDurationColumn(uint64_t span)
 {
     if (0 == span)
     {
+        // If given span is 0, use span of current tree item.
         if (isApiCall())
         {
             span = apiCallItem()->duration();
@@ -401,6 +402,26 @@ void vogleditor_apiCallTreeItem::setApiCallColumn(QString name)
 void vogleditor_apiCallTreeItem::setColumnData(QVariant data, int column)
 {
     m_columnData[column] = data;
+}
+
+bool vogleditor_apiCallTreeItem::isRenderGroup()
+{
+    return (apiCallColumn() == cTREEITEM_RENDER);
+}
+
+bool vogleditor_apiCallTreeItem::isStateChangeGroup()
+{
+    return (apiCallColumn() == cTREEITEM_STATECHANGES);
+}
+
+void vogleditor_apiCallTreeItem::setRenderGroup()
+{
+    setApiCallColumn(cTREEITEM_RENDER);
+}
+
+void vogleditor_apiCallTreeItem::setStateChangeGroup()
+{
+    setApiCallColumn(cTREEITEM_STATECHANGES);
 }
 
 QString vogleditor_apiCallTreeItem::apiCallColumn() const

--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -51,8 +51,8 @@ vogleditor_apiCallTreeItem::vogleditor_apiCallTreeItem(vogleditor_QApiCallTreeMo
     m_columnData[VOGL_ACTC_INDEX] = "Index";
     m_columnData[VOGL_ACTC_FLAGS] = "";
     m_columnData[VOGL_ACTC_GLCONTEXT] = "GL Context";
-    //m_ColumnTitles[VOGL_ACTC_BEGINTIME] = "Begin Time";
-    //m_ColumnTitles[VOGL_ACTC_ENDTIME] = "End Time";
+    //m_columnData[VOGL_ACTC_BEGINTIME] = "Begin Time";
+    //m_columnData[VOGL_ACTC_ENDTIME] = "End Time";
     m_columnData[VOGL_ACTC_DURATION] = "Duration (ns)";
 }
 
@@ -115,8 +115,8 @@ vogleditor_apiCallTreeItem::vogleditor_apiCallTreeItem(vogleditor_apiCallItem *a
         m_columnData[VOGL_ACTC_FLAGS] = "";
         dynamic_string strContext;
         m_columnData[VOGL_ACTC_GLCONTEXT] = strContext.format("0x%" PRIx64, apiCallItem->getGLPacket()->m_context_handle).c_str();
-        //m_columnData[VOGL_ACTC_BEGINTIME] = apiCallItem->startTime();
-        //m_columnData[VOGL_ACTC_ENDTIME] = apiCallItem->endTime();
+        //m_columnData[VOGL_ACTC_BEGINTIME] = (qulonglong)apiCallItem->startTime();
+        //m_columnData[VOGL_ACTC_ENDTIME] = (qulonglong)apiCallItem->endTime();
         m_columnData[VOGL_ACTC_DURATION] = (qulonglong)apiCallItem->duration();
     }
 

--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -169,6 +169,25 @@ bool vogleditor_apiCallTreeItem::isGroup() const
 {
     return (g_settings.group_state_render_stat() && (m_pGroupItem != NULL));
 }
+bool vogleditor_apiCallTreeItem::isGroupAncestry() const
+{
+    bool bRetVal = false;
+
+    if (g_settings.group_state_render_stat())
+    {
+        vogleditor_apiCallTreeItem const *pCallTreeItem = this;
+        while (pCallTreeItem)
+        {
+            if (pCallTreeItem->isGroup())
+            {
+                bRetVal = true;
+                break;
+            }
+            pCallTreeItem = pCallTreeItem->parent();
+        }
+    }
+    return bRetVal;
+}
 bool vogleditor_apiCallTreeItem::isFrame() const
 {
     return m_pFrameItem != NULL;

--- a/src/vogleditor/vogleditor_apicalltreeitem.h
+++ b/src/vogleditor/vogleditor_apicalltreeitem.h
@@ -111,6 +111,7 @@ public:
 
     bool isApiCall() const;
     bool isGroup() const;
+    bool isGroupAncestry() const;
     bool isFrame() const;
     bool isRoot() const;
 

--- a/src/vogleditor/vogleditor_apicalltreeitem.h
+++ b/src/vogleditor/vogleditor_apicalltreeitem.h
@@ -46,15 +46,16 @@ enum VOGL_API_CALL_TREE_COLUMN
     VOGL_ACTC_INDEX,
     VOGL_ACTC_GLCONTEXT,
     VOGL_ACTC_FLAGS,
-    //    VOGL_ACTC_BEGINTIME,
-    //    VOGL_ACTC_ENDTIME,
+    //VOGL_ACTC_BEGINTIME,
+    //VOGL_ACTC_ENDTIME,
     VOGL_ACTC_DURATION,
     VOGL_MAX_ACTC
 };
 
+// TODO: Maybe think about a less general group name for "Render" so as not to
+//       possibly be confused with a marker_push entrypoint name that could also
+//       be named "Render"
 const QString cTREEITEM_STATECHANGES("State changes");
-// TODO: Maybe think about a more unique name so as not to be confused with,
-//       e.g., a marker_push entrypoint that has also been named "Render"
 const QString cTREEITEM_RENDER("Render");
 
 class vogleditor_apiCallTreeItem
@@ -112,6 +113,12 @@ public:
     bool isGroup() const;
     bool isFrame() const;
     bool isRoot() const;
+
+    bool isRenderGroup();
+    bool isStateChangeGroup();
+
+    void setRenderGroup();
+    void setStateChangeGroup();
 
 private:
     void setColumnData(QVariant data, int column);

--- a/src/vogleditor/vogleditor_apicalltreeitem.h
+++ b/src/vogleditor/vogleditor_apicalltreeitem.h
@@ -56,7 +56,7 @@ enum VOGL_API_CALL_TREE_COLUMN
 //       possibly be confused with a marker_push entrypoint name that could also
 //       be named "Render"
 const QString cTREEITEM_STATECHANGES("State changes");
-const QString cTREEITEM_RENDER("Render");
+const QString cTREEITEM_RENDER("Draw calls");
 
 class vogleditor_apiCallTreeItem
 {

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -401,9 +401,9 @@ bool vogleditor_QApiCallTreeModel::init(vogl_trace_file_reader *pTrace_reader)
                 if (pCurParent->isGroup())
                 {
                     // If a series, set group name only once
-                    if (pCurParent->apiCallColumn() != cTREEITEM_RENDER)
+                    if (pCurParent->isStateChangeGroup())
                     {
-                        pCurParent->setApiCallColumn(cTREEITEM_RENDER);
+                        pCurParent->setRenderGroup();
                     }
                 }
             } // vogl_is_frame_buffer_write_entrypoint

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -299,7 +299,7 @@ bool vogleditor_QApiCallTreeModel::init(vogl_trace_file_reader *pTrace_reader)
                 // make apicall item
                 pCallItem = vogl_new(vogleditor_apiCallItem, pCurFrame, pTrace_packet, *pGL_packet);
                 pCurFrame->appendCall(pCallItem);
-                if (pCurParent->isGroup())
+                if (pCurParent->isGroupAncestry())
                 {
                     pCurGroup->appendCall(pCallItem);
                 }

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -455,7 +455,7 @@ bool vogleditor_QApiCallTreeModel::isStartNestedEntrypoint(gl_entrypoint_id_t id
     if (id != VOGL_ENTRYPOINT_INVALID)
     {
         QString funcname = g_vogl_entrypoint_descs[id].m_pName;
-        if (g_settings.is_active_nest_options(funcname) || g_settings.is_active_state_render_nest(funcname))
+        if (g_settings.is_active_nest_options(funcname) || g_settings.is_selected_state_render_nest(funcname))
         {
             return vogl_is_start_nested_entrypoint(id);
         }
@@ -467,7 +467,7 @@ bool vogleditor_QApiCallTreeModel::isEndNestedEntrypoint(gl_entrypoint_id_t id) 
     if (id != VOGL_ENTRYPOINT_INVALID)
     {
         QString funcname = g_vogl_entrypoint_descs[id].m_pName;
-        if (g_settings.is_active_nest_options(funcname) || g_settings.is_active_state_render_nest(funcname))
+        if (g_settings.is_active_nest_options(funcname) || g_settings.is_selected_state_render_nest(funcname))
         {
             return vogl_is_end_nested_entrypoint(id);
         }

--- a/src/vogleditor/vogleditor_qsettings.cpp
+++ b/src/vogleditor/vogleditor_qsettings.cpp
@@ -25,11 +25,11 @@ vogleditor_qsettings::vogleditor_qsettings()
     m_defaults.state_render_nest_list
         << "glBegin/glEnd";
 
-    m_defaults.debug_marker_list
+    m_defaults.debug_marker_name_list
         << "glPushDebugGroup/glPopDebugGroup"
         << "glPushGroupMarkerEXT/glPopGroupMarkerEXT";
 
-    m_defaults.nest_options_list
+    m_defaults.nest_options_name_list
         << "glBegin/glEnd"
         << "glNewList/glEndList"
         << "glPushMatrix/glPopMatrix"
@@ -43,13 +43,13 @@ vogleditor_qsettings::vogleditor_qsettings()
     m_defaults.state_render_used = true;
 
     // Debug marker
-    for (int i = 0, cnt = m_defaults.debug_marker_list.count(); i < cnt; i++)
+    for (int i = 0, cnt = m_defaults.debug_marker_name_list.count(); i < cnt; i++)
     {
-        m_defaults.debug_marker_stat << true;
-        m_defaults.debug_marker_used << true;
+        m_defaults.debug_marker_stat_list << true;
+        m_defaults.debug_marker_used_list << true;
     }
-    m_defaults.debug_marker_stat[1] = false; // glPush/PopGroupMarkerEXT
-    m_defaults.debug_marker_used[1] = false; // disable
+    m_defaults.debug_marker_stat_list[1] = false; // glPush/PopGroupMarkerEXT
+    m_defaults.debug_marker_used_list[1] = false; // disable
 
     m_defaults.debug_marker_option_name_labl = "Use text argument as label";
     m_defaults.debug_marker_option_name_stat = false;
@@ -63,16 +63,16 @@ vogleditor_qsettings::vogleditor_qsettings()
     m_defaults.groupbox_nest_options_name = "Nest options";
     m_defaults.groupbox_nest_options_stat = true;
     m_defaults.groupbox_nest_options_used = true;
-    for (int i = 0, cnt = m_defaults.nest_options_list.count(); i < cnt; i++)
+    for (int i = 0, cnt = m_defaults.nest_options_name_list.count(); i < cnt; i++)
     {
-        m_defaults.nest_options_stat << false;
-        m_defaults.nest_options_used << true;
+        m_defaults.nest_options_stat_list << false;
+        m_defaults.nest_options_used_list << true;
     }
-    m_defaults.nest_options_stat[0] = true; // glBegin/End
+    m_defaults.nest_options_stat_list[0] = true; // glBegin/End
 
     m_settings = m_defaults;
 
-    m_active_state_render_nest = active_state_render_nest();
+    m_active_state_render_nest_list = active_state_render_nest_list();
 
     update_group_active_lists();
 }
@@ -174,10 +174,10 @@ bool vogleditor_qsettings::from_json(const json_document &doc)
     m_settings.state_render_stat = pGroupsNode->value_as_bool(pKey.data(), m_settings.state_render_stat);
 
     // Debug marker list
-    for (int i = 0, cnt = m_settings.debug_marker_list.count(); i < cnt; i++)
+    for (int i = 0, cnt = m_settings.debug_marker_name_list.count(); i < cnt; i++)
     {
-        QByteArray pKey = m_settings.debug_marker_list[i].toLocal8Bit();
-        m_settings.debug_marker_stat[i] = pGroupsNode->value_as_bool(pKey.data(), m_settings.debug_marker_stat[i]);
+        QByteArray pKey = m_settings.debug_marker_name_list[i].toLocal8Bit();
+        m_settings.debug_marker_stat_list[i] = pGroupsNode->value_as_bool(pKey.data(), m_settings.debug_marker_stat_list[i]);
     }
     // Debug marker options
     pKey = m_settings.debug_marker_option_name_labl.toLocal8Bit();
@@ -190,10 +190,10 @@ bool vogleditor_qsettings::from_json(const json_document &doc)
     pKey = m_settings.groupbox_nest_options_name.toLocal8Bit();
     m_settings.groupbox_nest_options_stat = pGroupsNode->value_as_bool(pKey.data(), m_settings.groupbox_nest_options_stat);
 
-    for (int i = 0, cnt = m_settings.nest_options_list.count(); i < cnt; i++)
+    for (int i = 0, cnt = m_settings.nest_options_name_list.count(); i < cnt; i++)
     {
-        QByteArray pKey = m_settings.nest_options_list[i].toLocal8Bit();
-        m_settings.nest_options_stat[i] = pGroupsNode->value_as_bool(pKey.data(), m_settings.nest_options_stat[i]);
+        QByteArray pKey = m_settings.nest_options_name_list[i].toLocal8Bit();
+        m_settings.nest_options_stat_list[i] = pGroupsNode->value_as_bool(pKey.data(), m_settings.nest_options_stat_list[i]);
     }
 
     return true;
@@ -250,10 +250,10 @@ bool vogleditor_qsettings::to_json(json_document &doc)
     groups.add_key_value(pKey.data(), m_settings.state_render_stat);
 
     // Debug marker list
-    for (int i = 0, cnt = m_settings.debug_marker_list.count(); i < cnt; i++)
+    for (int i = 0, cnt = m_settings.debug_marker_name_list.count(); i < cnt; i++)
     {
-        const QByteArray pKey = m_settings.debug_marker_list[i].toLocal8Bit();
-        groups.add_key_value(pKey.data(), m_settings.debug_marker_stat[i]);
+        const QByteArray pKey = m_settings.debug_marker_name_list[i].toLocal8Bit();
+        groups.add_key_value(pKey.data(), m_settings.debug_marker_stat_list[i]);
     }
     // Debug marker options
     pKey = m_settings.debug_marker_option_name_labl.toLocal8Bit();
@@ -266,10 +266,10 @@ bool vogleditor_qsettings::to_json(json_document &doc)
     pKey = m_settings.groupbox_nest_options_name.toLocal8Bit();
     groups.add_key_value(pKey.data(), m_settings.groupbox_nest_options_stat);
 
-    for (int i = 0, cnt = m_settings.nest_options_list.count(); i < cnt; i++)
+    for (int i = 0, cnt = m_settings.nest_options_name_list.count(); i < cnt; i++)
     {
-        const QByteArray pKey = m_settings.nest_options_list[i].toLocal8Bit();
-        groups.add_key_value(pKey.data(), m_settings.nest_options_stat[i]);
+        const QByteArray pKey = m_settings.nest_options_name_list[i].toLocal8Bit();
+        groups.add_key_value(pKey.data(), m_settings.nest_options_stat_list[i]);
     }
 
     return true;

--- a/src/vogleditor/vogleditor_qsettings.h
+++ b/src/vogleditor/vogleditor_qsettings.h
@@ -19,29 +19,31 @@ struct vogleditor_setting_struct
     int window_size_height;
     unsigned int trim_large_trace_prompt_size;
 
-    QString state_render_name;
-    QStringList state_render_nest_list;
-    bool state_render_stat;
-    bool state_render_used;
+    // State/Render groups checkbox
+    QString state_render_name;          // checkbox label
+    bool state_render_stat;             // checked status of checkbox
+    bool state_render_used;             // enabled status of checkbox
+    QStringList state_render_nest_list; // list of allowable nest options
 
-    QStringList debug_marker_list;
-    QVector<bool> debug_marker_stat;
-    QVector<bool> debug_marker_used;
-
-    QString debug_marker_option_name_labl;
-    bool debug_marker_option_name_stat;
-    bool debug_marker_option_name_used;
-
+    // Debug marker groups groupbox
+    QStringList debug_marker_list;   // checkbox labels in groupbox
+    QVector<bool> debug_marker_stat; // checked status of checkboxes
+    QVector<bool> debug_marker_used; // enabled status of checkboxes
+    // TODO: seems these could also be made into QStringList and QVector<bool>
+    QString debug_marker_option_name_labl; // radiobutton labels in groupbox
     QString debug_marker_option_omit_labl;
+    bool debug_marker_option_name_stat; // checked status of radiobuttons
     bool debug_marker_option_omit_stat;
+    bool debug_marker_option_name_used; // enabled status of radiobuttons
     bool debug_marker_option_omit_used;
 
-    QString groupbox_nest_options_name;
-    bool groupbox_nest_options_stat;
-    bool groupbox_nest_options_used;
-    QStringList nest_options_list;
-    QVector<bool> nest_options_stat;
-    QVector<bool> nest_options_used;
+    // Nest options groupbox
+    QString groupbox_nest_options_name; // checkbox label of groupbox header
+    bool groupbox_nest_options_stat;    // checked status of header checkbox
+    bool groupbox_nest_options_used;    // enabled status of header checkbox
+    QStringList nest_options_list;      // checkbox labels in groupbox
+    QVector<bool> nest_options_stat;    // checked status of checkboxes
+    QVector<bool> nest_options_used;    // enabled status of checkboxes
 };
 
 class vogleditor_qsettings : public QObject

--- a/src/vogleditor/vogleditor_qsettings.h
+++ b/src/vogleditor/vogleditor_qsettings.h
@@ -26,9 +26,9 @@ struct vogleditor_setting_struct
     QStringList state_render_nest_list; // list of allowable nest options
 
     // Debug marker groups groupbox
-    QStringList debug_marker_list;   // checkbox labels in groupbox
-    QVector<bool> debug_marker_stat; // checked status of checkboxes
-    QVector<bool> debug_marker_used; // enabled status of checkboxes
+    QStringList debug_marker_name_list;   // checkbox labels in groupbox
+    QVector<bool> debug_marker_stat_list; // checked status of checkboxes
+    QVector<bool> debug_marker_used_list; // enabled status of checkboxes
     // TODO: seems these could also be made into QStringList and QVector<bool>
     QString debug_marker_option_name_labl; // radiobutton labels in groupbox
     QString debug_marker_option_omit_labl;
@@ -38,12 +38,12 @@ struct vogleditor_setting_struct
     bool debug_marker_option_omit_used;
 
     // Nest options groupbox
-    QString groupbox_nest_options_name; // checkbox label of groupbox header
-    bool groupbox_nest_options_stat;    // checked status of header checkbox
-    bool groupbox_nest_options_used;    // enabled status of header checkbox
-    QStringList nest_options_list;      // checkbox labels in groupbox
-    QVector<bool> nest_options_stat;    // checked status of checkboxes
-    QVector<bool> nest_options_used;    // enabled status of checkboxes
+    QString groupbox_nest_options_name;   // checkbox label of groupbox header
+    bool groupbox_nest_options_stat;      // checked status of header checkbox
+    bool groupbox_nest_options_used;      // enabled status of header checkbox
+    QStringList nest_options_name_list;   // checkbox labels in groupbox
+    QVector<bool> nest_options_stat_list; // checked status of checkboxes
+    QVector<bool> nest_options_used_list; // enabled status of checkboxes
 };
 
 class vogleditor_qsettings : public QObject
@@ -139,27 +139,27 @@ public:
     }
 
     // Debug marker
-    QStringList group_debug_marker_names()
+    QStringList group_debug_marker_name_list()
     {
-        return m_settings.debug_marker_list;
+        return m_settings.debug_marker_name_list;
     }
 
-    QVector<bool> group_debug_marker_stat()
+    QVector<bool> group_debug_marker_stat_list()
     {
-        return m_settings.debug_marker_stat;
+        return m_settings.debug_marker_stat_list;
     }
-    void set_group_debug_marker_stat(QVector<bool> debug_marker_stat)
+    void set_group_debug_marker_stat_list(QVector<bool> debug_marker_stat_list)
     {
-        m_settings.debug_marker_stat = debug_marker_stat;
+        m_settings.debug_marker_stat_list = debug_marker_stat_list;
     }
 
-    QVector<bool> group_debug_marker_used()
+    QVector<bool> group_debug_marker_used_list()
     {
-        return m_settings.debug_marker_used;
+        return m_settings.debug_marker_used_list;
     }
-    void set_group_debug_marker_used(QVector<bool> debug_marker_used)
+    void set_group_debug_marker_used_list(QVector<bool> debug_marker_used_list)
     {
-        m_settings.debug_marker_used = debug_marker_used;
+        m_settings.debug_marker_used_list = debug_marker_used_list;
     }
 
     QString group_debug_marker_option_name_label()
@@ -226,51 +226,51 @@ public:
     }
 
     // Checkboxes
-    QStringList group_nest_options_names()
+    QStringList group_nest_options_name_list()
     {
-        return m_settings.nest_options_list;
+        return m_settings.nest_options_name_list;
     }
-    QVector<bool> group_nest_options_stat()
+    QVector<bool> group_nest_options_stat_list()
     {
-        return m_settings.nest_options_stat;
+        return m_settings.nest_options_stat_list;
     }
-    void set_group_nest_options_stat(QVector<bool> nest_options_stat)
+    void set_group_nest_options_stat_list(QVector<bool> nest_options_stat_list)
     {
-        m_settings.nest_options_stat = nest_options_stat;
+        m_settings.nest_options_stat_list = nest_options_stat_list;
     }
-    QVector<bool> group_nest_options_used()
+    QVector<bool> group_nest_options_used_list()
     {
-        return m_settings.nest_options_used;
+        return m_settings.nest_options_used_list;
     }
-    void set_group_nest_options_used(QVector<bool> nest_options_used)
+    void set_group_nest_options_used_list(QVector<bool> nest_options_used_list)
     {
-        m_settings.nest_options_used = nest_options_used;
+        m_settings.nest_options_used_list = nest_options_used_list;
     }
 
     void update_group_active_lists()
     {
-        m_active_debug_marker = active_debug_marker();
-        m_active_nest_options = active_nest_options();
+        m_active_debug_marker_list = active_debug_marker_list();
+        m_active_nest_options_list = active_nest_options_list();
         emit treeDisplayChanged();
     }
 
-    bool is_active_state_render_nest(QString str)
+    bool is_selected_state_render_nest(QString str)
     {
         // Use allowed nest calls with State/Render groups if selected under
         // Nest options (even though nest call item is disabled)
-        return m_active_state_render_nest.contains(str) && m_settings.state_render_stat && m_active_nest_options.contains(str);
+        return m_active_state_render_nest_list.contains(str) && m_settings.state_render_stat && m_active_nest_options_list.contains(str);
     }
     bool is_active_debug_marker(QString str)
     {
-        return m_active_debug_marker.contains(str);
+        return m_active_debug_marker_list.contains(str);
     }
     bool is_active_nest_options(QString str)
     {
-        return m_settings.groupbox_nest_options_stat && m_active_nest_options.contains(str);
+        return m_settings.groupbox_nest_options_stat && m_active_nest_options_list.contains(str);
     }
 
 private:
-    const QStringList active_state_render_nest() const
+    const QStringList active_state_render_nest_list() const
     {
         QStringList activeList;
         for (int i = 0; i < m_settings.state_render_nest_list.count(); i++)
@@ -279,28 +279,28 @@ private:
         }
         return activeList;
     }
-    const QStringList active_debug_marker() const
+    const QStringList active_debug_marker_list() const
     {
 
         QStringList activeList;
-        for (int i = 0; i < m_settings.debug_marker_list.count(); i++)
+        for (int i = 0; i < m_settings.debug_marker_name_list.count(); i++)
         {
-            if (m_settings.debug_marker_stat[i])
+            if (m_settings.debug_marker_stat_list[i])
             {
-                activeList << m_settings.debug_marker_list[i].split("/");
+                activeList << m_settings.debug_marker_name_list[i].split("/");
             }
         }
         return activeList;
     }
-    const QStringList active_nest_options() const
+    const QStringList active_nest_options_list() const
     {
 
         QStringList activeList;
-        for (int i = 0; i < m_settings.nest_options_list.count(); i++)
+        for (int i = 0; i < m_settings.nest_options_name_list.count(); i++)
         {
-            if (m_settings.nest_options_stat[i])
+            if (m_settings.nest_options_stat_list[i])
             {
-                activeList << m_settings.nest_options_list[i].split("/");
+                activeList << m_settings.nest_options_name_list[i].split("/");
             }
         }
         return activeList;
@@ -311,9 +311,9 @@ private:
     vogleditor_setting_struct m_settings;
     vogleditor_setting_struct m_defaults;
 
-    QStringList m_active_state_render_nest;
-    QStringList m_active_debug_marker;
-    QStringList m_active_nest_options;
+    QStringList m_active_state_render_nest_list;
+    QStringList m_active_debug_marker_list;
+    QStringList m_active_nest_options_list;
 
     vogl::dynamic_string get_settings_path();
     bool to_json(vogl::json_document &doc);

--- a/src/vogleditor/vogleditor_qsettings.h
+++ b/src/vogleditor/vogleditor_qsettings.h
@@ -205,6 +205,11 @@ public:
         m_settings.debug_marker_option_omit_used = used;
     }
 
+    bool group_debug_marker_in_use()
+    {
+        return group_debug_marker_stat_list().contains(true);
+    }
+
     // Nest options
 
     // Groupbox

--- a/src/vogleditor/vogleditor_qsettingsdialog.cpp
+++ b/src/vogleditor/vogleditor_qsettingsdialog.cpp
@@ -37,9 +37,9 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
     // Debug markers
     QVector<QCheckBox *> checkboxList;
 
-    QStringList group_debug_marker_names = g_settings.group_debug_marker_names();
-    QVector<bool> debug_marker_stat = g_settings.group_debug_marker_stat();
-    QVector<bool> debug_marker_used = g_settings.group_debug_marker_used();
+    QStringList group_debug_marker_names = g_settings.group_debug_marker_name_list();
+    QVector<bool> debug_marker_stat = g_settings.group_debug_marker_stat_list();
+    QVector<bool> debug_marker_used = g_settings.group_debug_marker_used_list();
     int debug_marker_cnt = group_debug_marker_names.size();
     for (int i = 0; i < debug_marker_cnt; i++)
     {
@@ -83,9 +83,9 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
     }
 
     // Checkboxes
-    QStringList group_nest_options_names = g_settings.group_nest_options_names();
-    QVector<bool> nest_options_stat = g_settings.group_nest_options_stat();
-    QVector<bool> nest_options_used = g_settings.group_nest_options_used();
+    QStringList group_nest_options_names = g_settings.group_nest_options_name_list();
+    QVector<bool> nest_options_stat = g_settings.group_nest_options_stat_list();
+    QVector<bool> nest_options_used = g_settings.group_nest_options_used_list();
     int nest_options_cnt = group_nest_options_names.size();
     for (int i = 0; i < nest_options_cnt; i++)
     {
@@ -165,8 +165,8 @@ void vogleditor_QSettingsDialog::groupboxNestOptionsCB(bool bVal)
 void vogleditor_QSettingsDialog::checkboxCB(int state)
 {
     g_settings.set_group_state_render_stat(ui->checkboxStateRender->isChecked());
-    g_settings.set_group_debug_marker_stat(checkboxValues(ui->groupboxDebugMarker));
-    g_settings.set_group_nest_options_stat(checkboxValues(ui->groupboxNestOptions));
+    g_settings.set_group_debug_marker_stat_list(checkboxValues(ui->groupboxDebugMarker));
+    g_settings.set_group_nest_options_stat_list(checkboxValues(ui->groupboxNestOptions));
 
     setEnableDebugMarkerOptions();
 

--- a/src/vogleditor/vogleditor_qtimelineview.cpp
+++ b/src/vogleditor/vogleditor_qtimelineview.cpp
@@ -32,6 +32,7 @@
 
 vogleditor_QTimelineView::vogleditor_QTimelineView(QWidget *parent)
     : QWidget(parent),
+      m_roundoff(cVOGL_TIMELINEOFFSET),
       m_curFrame(0),
       m_curApiCallNumber(0),
       m_pModel(NULL),
@@ -58,16 +59,6 @@ vogleditor_QTimelineView::vogleditor_QTimelineView(QWidget *parent)
 
     m_horizontalScale = 1;
     m_lineLength = 1;
-
-    char *envptr = getenv("VOGL_TIMELINEOFFSET");
-    if (envptr)
-    {
-        m_roundoff = QString(envptr).toFloat();
-    }
-    else
-    {
-        m_roundoff = 0.085;
-    }
 }
 
 vogleditor_QTimelineView::~vogleditor_QTimelineView()

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -98,10 +98,10 @@ private:
     QPen m_trianglePen;
     QPen m_textPen;
     QFont m_textFont;
+    float m_roundoff;
     float m_horizontalScale;
     int m_lineLength;
     unsigned long long m_curFrame;
-    unsigned long long m_curGroup;
     unsigned long long m_curApiCallNumber;
     float m_maxItemDuration;
 

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -40,6 +40,8 @@ QT_END_NAMESPACE
 #include "vogleditor_timelinemodel.h"
 #include "vogleditor_timelineitem.h"
 
+static const float cVOGL_TIMELINEOFFSET = 0.085f;
+
 class vogleditor_QTimelineView : public QWidget
 {
     Q_OBJECT

--- a/src/vogleditor/vogleditor_timelineitem.h
+++ b/src/vogleditor/vogleditor_timelineitem.h
@@ -94,9 +94,6 @@ public:
     }
 
 private:
-    unsigned int randomRGB();
-
-private:
     QBrush *m_brush;
     float m_beginTime;
     float m_endTime;

--- a/src/vogleditor/vogleditor_timelineitem.h
+++ b/src/vogleditor/vogleditor_timelineitem.h
@@ -27,16 +27,18 @@
 #define VOGLEDITOR_TIMELINEITEM_H
 
 #include <QList>
-#include <QBrush>
+class QBrush;
 
 class vogleditor_frameItem;
+class vogleditor_groupItem;
 class vogleditor_apiCallItem;
 
 class vogleditor_timelineItem
 {
 public:
-    vogleditor_timelineItem(float time, vogleditor_timelineItem *parent, vogleditor_frameItem *frameItem);
     vogleditor_timelineItem(float begin, float end);
+    vogleditor_timelineItem(float time, vogleditor_timelineItem *parent, vogleditor_frameItem *groupItem);
+    vogleditor_timelineItem(float begin, float end, vogleditor_timelineItem *parent, vogleditor_groupItem *groupItem);
     vogleditor_timelineItem(float begin, float end, vogleditor_timelineItem *parent, vogleditor_apiCallItem *apiCallItem);
     ~vogleditor_timelineItem();
 
@@ -60,9 +62,20 @@ public:
     bool isSpan() const;
     bool isMarker() const;
 
+    // (Currently only isGroupItem() is used)
+    bool isApiCallItem();
+    bool isGroupItem();
+    bool isFrameItem();
+    bool isRootItem();
+
     vogleditor_frameItem *getFrameItem() const
     {
         return m_pFrameItem;
+    }
+
+    vogleditor_groupItem *getGroupItem() const
+    {
+        return m_pGroupItem;
     }
 
     void setFrameItem(vogleditor_frameItem *pFrameItem)
@@ -81,6 +94,9 @@ public:
     }
 
 private:
+    unsigned int randomRGB();
+
+private:
     QBrush *m_brush;
     float m_beginTime;
     float m_endTime;
@@ -92,6 +108,7 @@ private:
 
     vogleditor_timelineItem *m_parentItem;
     vogleditor_frameItem *m_pFrameItem;
+    vogleditor_groupItem *m_pGroupItem;
     vogleditor_apiCallItem *m_pApiCallItem;
 };
 


### PR DESCRIPTION
These changes only have an affect if a groups option is selected from the Settings dialog. See the commit message for the individual "UI: Color code timeline for groups" commit for details (same title as for the group of commits)

This is a normal display:
![normal](https://cloud.githubusercontent.com/assets/6090880/5886153/ffb1963e-a340-11e4-865c-272523e74171.png)

(Note there is a staircase effect for nested elements and continue with groups)
![nested-calls](https://cloud.githubusercontent.com/assets/6090880/5886164/ca57a5ae-a341-11e4-9a15-f5b399ee19d1.png)

A first stab at issue #121 for Debug marker groups (with default colored API calls not in debug groups)
![debug-marker-groups](https://cloud.githubusercontent.com/assets/6090880/5886176/21327f52-a342-11e4-9eb3-5fd671e023ad.png)

Combination of State/Render and Debug groups. State/Render groups use a pattern to differentiate from Debug groups and API calls not in groups:
![state-render-and-debug-marker-groups](https://cloud.githubusercontent.com/assets/6090880/5886177/3634d076-a342-11e4-830d-47298438ef99.png)

State/Render groups alone (no other options):
![state-render-groups](https://cloud.githubusercontent.com/assets/6090880/5886175/0aeedc72-a342-11e4-817c-655dbfba676c.png)
