### PR TITLE
UI: rename some more groups settings API names

### DIFF
--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -461,5 +461,5 @@ int vogleditor_apiCallTreeItem::row() const
 
 gl_entrypoint_id_t vogleditor_apiCallTreeItem::entrypoint_id() const
 {
-   return m_pApiCallItem ? m_pApiCallItem->getTracePacket()->get_entrypoint_id() : VOGL_ENTRYPOINT_INVALID;
+    return m_pApiCallItem ? m_pApiCallItem->getTracePacket()->get_entrypoint_id() : VOGL_ENTRYPOINT_INVALID;
 }

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -488,12 +488,12 @@ bool vogleditor_QApiCallTreeModel::isFrameBufferWriteEntrypoint(gl_entrypoint_id
 
 bool vogleditor_QApiCallTreeModel::displayMarkerTextAsLabel() const
 {
-    return g_settings.group_debug_marker_option_name_stat() && g_settings.group_debug_marker_option_name_used();
+    return g_settings.group_debug_marker_option_name_stat() && g_settings.group_debug_marker_option_name_able();
 }
 
 bool vogleditor_QApiCallTreeModel::hideMarkerPopApiCall() const
 {
-    return g_settings.group_debug_marker_option_omit_stat() && g_settings.group_debug_marker_option_omit_used();
+    return g_settings.group_debug_marker_option_omit_stat() && g_settings.group_debug_marker_option_omit_able();
 }
 
 gl_entrypoint_id_t vogleditor_QApiCallTreeModel::itemApiCallId(vogleditor_apiCallTreeItem *apiCallTreeItem) const

--- a/src/vogleditor/vogleditor_qsettings.cpp
+++ b/src/vogleditor/vogleditor_qsettings.cpp
@@ -40,33 +40,33 @@ vogleditor_qsettings::vogleditor_qsettings()
     // State/Render
     m_defaults.state_render_name = "State/Render groups";
     m_defaults.state_render_stat = false;
-    m_defaults.state_render_used = true;
+    m_defaults.state_render_able = true;
 
     // Debug marker
     for (int i = 0, cnt = m_defaults.debug_marker_name_list.count(); i < cnt; i++)
     {
         m_defaults.debug_marker_stat_list << true;
-        m_defaults.debug_marker_used_list << true;
+        m_defaults.debug_marker_able_list << true;
     }
     m_defaults.debug_marker_stat_list[1] = false; // glPush/PopGroupMarkerEXT
-    m_defaults.debug_marker_used_list[1] = false; // disable
+    m_defaults.debug_marker_able_list[1] = false; // disable
 
     m_defaults.debug_marker_option_name_labl = "Use text argument as label";
     m_defaults.debug_marker_option_name_stat = false;
-    m_defaults.debug_marker_option_name_used = true;
+    m_defaults.debug_marker_option_name_able = true;
 
     m_defaults.debug_marker_option_omit_labl = "Hide terminating API call";
     m_defaults.debug_marker_option_omit_stat = false;
-    m_defaults.debug_marker_option_omit_used = true;
+    m_defaults.debug_marker_option_omit_able = true;
 
     // Nest options
     m_defaults.groupbox_nest_options_name = "Nest options";
     m_defaults.groupbox_nest_options_stat = true;
-    m_defaults.groupbox_nest_options_used = true;
+    m_defaults.groupbox_nest_options_able = true;
     for (int i = 0, cnt = m_defaults.nest_options_name_list.count(); i < cnt; i++)
     {
         m_defaults.nest_options_stat_list << false;
-        m_defaults.nest_options_used_list << true;
+        m_defaults.nest_options_able_list << true;
     }
     m_defaults.nest_options_stat_list[0] = true; // glBegin/End
 

--- a/src/vogleditor/vogleditor_qsettings.h
+++ b/src/vogleditor/vogleditor_qsettings.h
@@ -22,28 +22,28 @@ struct vogleditor_setting_struct
     // State/Render groups checkbox
     QString state_render_name;          // checkbox label
     bool state_render_stat;             // checked status of checkbox
-    bool state_render_used;             // enabled status of checkbox
+    bool state_render_able;             // enabled status of checkbox
     QStringList state_render_nest_list; // list of allowable nest options
 
     // Debug marker groups groupbox
     QStringList debug_marker_name_list;   // checkbox labels in groupbox
     QVector<bool> debug_marker_stat_list; // checked status of checkboxes
-    QVector<bool> debug_marker_used_list; // enabled status of checkboxes
+    QVector<bool> debug_marker_able_list; // enabled status of checkboxes
     // TODO: seems these could also be made into QStringList and QVector<bool>
     QString debug_marker_option_name_labl; // radiobutton labels in groupbox
     QString debug_marker_option_omit_labl;
     bool debug_marker_option_name_stat; // checked status of radiobuttons
     bool debug_marker_option_omit_stat;
-    bool debug_marker_option_name_used; // enabled status of radiobuttons
-    bool debug_marker_option_omit_used;
+    bool debug_marker_option_name_able; // enabled status of radiobuttons
+    bool debug_marker_option_omit_able;
 
     // Nest options groupbox
     QString groupbox_nest_options_name;   // checkbox label of groupbox header
     bool groupbox_nest_options_stat;      // checked status of header checkbox
-    bool groupbox_nest_options_used;      // enabled status of header checkbox
+    bool groupbox_nest_options_able;      // enabled status of header checkbox
     QStringList nest_options_name_list;   // checkbox labels in groupbox
     QVector<bool> nest_options_stat_list; // checked status of checkboxes
-    QVector<bool> nest_options_used_list; // enabled status of checkboxes
+    QVector<bool> nest_options_able_list; // enabled status of checkboxes
 };
 
 class vogleditor_qsettings : public QObject
@@ -133,9 +133,9 @@ public:
     {
         m_settings.state_render_stat = state_render_stat;
     }
-    bool group_state_render_used()
+    bool group_state_render_able()
     {
-        return m_settings.state_render_used;
+        return m_settings.state_render_able;
     }
 
     // Debug marker
@@ -153,13 +153,13 @@ public:
         m_settings.debug_marker_stat_list = debug_marker_stat_list;
     }
 
-    QVector<bool> group_debug_marker_used_list()
+    QVector<bool> group_debug_marker_able_list()
     {
-        return m_settings.debug_marker_used_list;
+        return m_settings.debug_marker_able_list;
     }
-    void set_group_debug_marker_used_list(QVector<bool> debug_marker_used_list)
+    void set_group_debug_marker_able_list(QVector<bool> debug_marker_able_list)
     {
-        m_settings.debug_marker_used_list = debug_marker_used_list;
+        m_settings.debug_marker_able_list = debug_marker_able_list;
     }
 
     QString group_debug_marker_option_name_label()
@@ -170,9 +170,9 @@ public:
     {
         return m_settings.debug_marker_option_name_stat;
     }
-    bool group_debug_marker_option_name_used()
+    bool group_debug_marker_option_name_able()
     {
-        return m_settings.debug_marker_option_name_used;
+        return m_settings.debug_marker_option_name_able;
     }
 
     QString group_debug_marker_option_omit_label()
@@ -183,26 +183,26 @@ public:
     {
         return m_settings.debug_marker_option_omit_stat;
     }
-    bool group_debug_marker_option_omit_used()
+    bool group_debug_marker_option_omit_able()
     {
-        return m_settings.debug_marker_option_omit_used;
+        return m_settings.debug_marker_option_omit_able;
     }
 
     void set_group_debug_marker_option_name_stat(bool stat)
     {
         m_settings.debug_marker_option_name_stat = stat;
     }
-    void set_group_debug_marker_option_name_used(bool used)
+    void set_group_debug_marker_option_name_able(bool used)
     {
-        m_settings.debug_marker_option_name_used = used;
+        m_settings.debug_marker_option_name_able = used;
     }
     void set_group_debug_marker_option_omit_stat(bool stat)
     {
         m_settings.debug_marker_option_omit_stat = stat;
     }
-    void set_group_debug_marker_option_omit_used(bool used)
+    void set_group_debug_marker_option_omit_able(bool used)
     {
-        m_settings.debug_marker_option_omit_used = used;
+        m_settings.debug_marker_option_omit_able = used;
     }
 
     bool group_debug_marker_in_use()
@@ -225,9 +225,9 @@ public:
     {
         m_settings.groupbox_nest_options_stat = b_val;
     }
-    bool groupbox_nest_options_used()
+    bool groupbox_nest_options_able()
     {
-        return m_settings.groupbox_nest_options_used;
+        return m_settings.groupbox_nest_options_able;
     }
 
     // Checkboxes
@@ -243,13 +243,13 @@ public:
     {
         m_settings.nest_options_stat_list = nest_options_stat_list;
     }
-    QVector<bool> group_nest_options_used_list()
+    QVector<bool> group_nest_options_able_list()
     {
-        return m_settings.nest_options_used_list;
+        return m_settings.nest_options_able_list;
     }
-    void set_group_nest_options_used_list(QVector<bool> nest_options_used_list)
+    void set_group_nest_options_able_list(QVector<bool> nest_options_able_list)
     {
-        m_settings.nest_options_used_list = nest_options_used_list;
+        m_settings.nest_options_able_list = nest_options_able_list;
     }
 
     void update_group_active_lists()

--- a/src/vogleditor/vogleditor_qsettingsdialog.cpp
+++ b/src/vogleditor/vogleditor_qsettingsdialog.cpp
@@ -29,7 +29,7 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
     // State Render
     ui->checkboxStateRender->setText(g_settings.group_state_render_name());
     ui->checkboxStateRender->setChecked(g_settings.group_state_render_stat());
-    ui->checkboxStateRender->setEnabled(g_settings.group_state_render_used());
+    ui->checkboxStateRender->setEnabled(g_settings.group_state_render_able());
 
     connect(ui->checkboxStateRender, SIGNAL(stateChanged(int)),
             SLOT(checkboxStateRenderCB(int)));
@@ -39,13 +39,13 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
 
     QStringList group_debug_marker_names = g_settings.group_debug_marker_name_list();
     QVector<bool> debug_marker_stat = g_settings.group_debug_marker_stat_list();
-    QVector<bool> debug_marker_used = g_settings.group_debug_marker_used_list();
+    QVector<bool> debug_marker_able = g_settings.group_debug_marker_able_list();
     int debug_marker_cnt = group_debug_marker_names.size();
     for (int i = 0; i < debug_marker_cnt; i++)
     {
         checkboxList << new QCheckBox(group_debug_marker_names[i], ui->groupboxDebugMarker);
         checkboxList[i]->setChecked(debug_marker_stat[i]);
-        checkboxList[i]->setEnabled(debug_marker_used[i]);
+        checkboxList[i]->setEnabled(debug_marker_able[i]);
         ui->vLayout_groupboxDebugMarker->insertWidget(i, checkboxList[i]);
     }
 
@@ -75,7 +75,7 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
     // Groupbox
     ui->groupboxNestOptions->setTitle(g_settings.groupbox_nest_options_name());
     ui->groupboxNestOptions->setChecked(g_settings.groupbox_nest_options_stat());
-    ui->groupboxNestOptions->setEnabled(g_settings.groupbox_nest_options_used());
+    ui->groupboxNestOptions->setEnabled(g_settings.groupbox_nest_options_able());
     if (g_settings.groupbox_nest_options_stat())
     {
         // For now, toggle State/Render groups and Nest options
@@ -85,13 +85,13 @@ vogleditor_QSettingsDialog::vogleditor_QSettingsDialog(QWidget *parent)
     // Checkboxes
     QStringList group_nest_options_names = g_settings.group_nest_options_name_list();
     QVector<bool> nest_options_stat = g_settings.group_nest_options_stat_list();
-    QVector<bool> nest_options_used = g_settings.group_nest_options_used_list();
+    QVector<bool> nest_options_able = g_settings.group_nest_options_able_list();
     int nest_options_cnt = group_nest_options_names.size();
     for (int i = 0; i < nest_options_cnt; i++)
     {
         checkboxList << new QCheckBox(group_nest_options_names[i], ui->groupboxNestOptions);
         checkboxList[i]->setChecked(nest_options_stat[i]);
-        checkboxList[i]->setEnabled(nest_options_used[i]);
+        checkboxList[i]->setEnabled(nest_options_able[i]);
         ui->vLayout_groupboxNestOptionsScrollarea->addWidget(checkboxList[i]);
     }
 
@@ -193,8 +193,8 @@ void vogleditor_QSettingsDialog::enableDebugMarkerOptions(bool bVal)
     ui->radiobuttonDebugMarkerOmitOption->setEnabled(bVal);
 
     // Notify g_settings
-    g_settings.set_group_debug_marker_option_name_used(bVal);
-    g_settings.set_group_debug_marker_option_omit_used(bVal);
+    g_settings.set_group_debug_marker_option_name_able(bVal);
+    g_settings.set_group_debug_marker_option_omit_able(bVal);
 }
 
 void vogleditor_QSettingsDialog::radiobuttonNameCB(bool state)


### PR DESCRIPTION
(No logic changes)

The groups settings APIs were incorporating the extension "_used" in
APIs that indicate if the widget is "enabled" i.e., greyed out or not.

While reading some code in review, that term wasn't clear in
distinguishing it from the widget's "checked" or "selected" status. A
more apt name that would reflect its use better is "_able", i.e.,
instead of, e.g.,

    m_defaults.state_render_used
using

    m_defaults.state_render_able

would make for clearer reading of the code

Renamed these APIs using "_used" to "_able".

Signed-off-by: Lawrence L Love <lawrencex.l.love@intel.com>