### PR TITLE
Fix for Issue #199;

### DIFF
--- a/src/libbacktrace/CMakeLists.txt
+++ b/src/libbacktrace/CMakeLists.txt
@@ -116,7 +116,7 @@ else ()
     set (BACKTRACE_SUPPORTED 0)
 endif ()
 
-check_symbol_exists (mmap sys/mman.h HAVE_MMAP)
+check_symbol_exists (mmap "sys/mman.h" HAVE_MMAP)
 
 if (HAVE_MMAP)
     set (VIEW_FILE mmapio.c)

--- a/src/libbacktrace/alloc.c
+++ b/src/libbacktrace/alloc.c
@@ -33,6 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
 #include "config.h"
 
 #include <errno.h>
+#include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>
 
@@ -59,7 +60,34 @@ backtrace_alloc (struct backtrace_state *state ATTRIBUTE_UNUSED,
   return ret;
 }
 
-/* Free memory.  */
+/* Allocate memory like strdup. */
+
+char *
+backtrace_strdup (struct backtrace_state *state, const char *str,
+                  backtrace_error_callback error_callback,
+                  void *data)
+{
+   char *ret;
+
+   ret = NULL;
+
+   if (str)
+   {
+      size_t size;
+      void *mem;
+
+      size = strlen(str) + 1;
+      mem = backtrace_alloc (state, size, error_callback, data);
+      if (mem)
+      {
+         memcpy(mem, str, size);
+         ret = (char *)mem;
+      }
+   }
+   return ret;
+}
+
+/* Free memory allocated by backtrace_alloc.  */
 
 void
 backtrace_free (struct backtrace_state *state ATTRIBUTE_UNUSED,


### PR DESCRIPTION
alloc.c if it was being used for libbacktrace was missing the definition
for backtrace_strdup.

Changes:
=======

src/libbacktrace/CMakeLists.txt
  (1) quotes around the header (matching the `cmake` documentation for use the function);

src/libbacktrace/alloc.c:
  (1) added `#include <string.h>` required for the use of `memcpy`
  (2) `backtrace_strdup` definition [copied from `src/libbacktrace/mmap.c`]