### PR TITLE
Interactive time line

### DIFF
--- a/src/vogleditor/vogleditor.cpp
+++ b/src/vogleditor/vogleditor.cpp
@@ -2681,17 +2681,17 @@ void VoglEditor::setTimeline(vogleditor_apiCallTreeItem *pCallTreeItem)
 
     if (pApiCallItem != NULL)
     {
-        m_timeline->setCurrentApiCall(pApiCallItem->globalCallIndex());
+        m_timeline->setCurrentApiCall(pApiCallItem);
     }
 
     if (pGroupItem != NULL)
     {
-        m_timeline->setCurrentGroup(pGroupItem->firstApiCallIndex());
+        m_timeline->setCurrentGroup(pGroupItem);
     }
 
     if (pFrameItem != NULL)
     {
-        m_timeline->setCurrentFrame(pFrameItem->frameNumber());
+        m_timeline->setCurrentFrame(pFrameItem);
     }
 
     m_timeline->repaint();

--- a/src/vogleditor/vogleditor.cpp
+++ b/src/vogleditor/vogleditor.cpp
@@ -230,7 +230,7 @@ VoglEditor::VoglEditor(QWidget *parent)
     connect(m_pVoglReplayProcess, SIGNAL(readyReadStandardOutput()), this, SLOT(slot_readReplayStandardOutput()));
     connect(m_pVoglReplayProcess, SIGNAL(readyReadStandardError()), this, SLOT(slot_readReplayStandardError()));
 
-    connect(m_timeline, SIGNAL(timelineItemClicked(vogleditor_apiCallItem *)), this, SLOT(selectAPICallItem(vogleditor_apiCallItem *)));
+    connect(m_timeline, SIGNAL(timelineItemClicked(vogleditor_snapshotItem *)), this, SLOT(selectAPICallItem(vogleditor_snapshotItem *)));
 
     reset_tracefile_ui();
 }
@@ -2961,7 +2961,7 @@ void VoglEditor::on_treeView_activated(const QModelIndex &index)
     onApiCallSelected(index, true);
 }
 
-void VoglEditor::selectAPICallItem(vogleditor_apiCallItem *pItem)
+void VoglEditor::selectAPICallItem(vogleditor_snapshotItem *pItem)
 {
     QModelIndexList hits = m_pApiCallTreeModel->match(m_pApiCallTreeModel->index(0, 0), Qt::UserRole, QVariant::fromValue((void*)pItem), 1, Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap);
     if (hits.count() > 0)

--- a/src/vogleditor/vogleditor.cpp
+++ b/src/vogleditor/vogleditor.cpp
@@ -31,6 +31,7 @@
 #include <QMessageBox>
 #include <QCoreApplication>
 #include <QGraphicsBlurEffect>
+#include <QScrollBar>
 
 #include "ui_vogleditor.h"
 #include "vogleditor.h"
@@ -181,10 +182,11 @@ VoglEditor::VoglEditor(QWidget *parent)
     // setup timeline
     m_timeline = new vogleditor_QTimelineView();
     m_timeline->setMinimumHeight(100);
-    ui->timelineLayout->addWidget(m_timeline);
     ui->timelineLayout->removeWidget(ui->timelineViewPlaceholder);
     delete ui->timelineViewPlaceholder;
     ui->timelineViewPlaceholder = NULL;
+    ui->timelineLayout->insertWidget(0, m_timeline);
+    m_timeline->setScrollBar(ui->timelineScrollBar);
 
     // add buttons to toolbar
     m_pGenerateTraceButton = new QToolButton(ui->mainToolBar);

--- a/src/vogleditor/vogleditor.cpp
+++ b/src/vogleditor/vogleditor.cpp
@@ -230,6 +230,8 @@ VoglEditor::VoglEditor(QWidget *parent)
     connect(m_pVoglReplayProcess, SIGNAL(readyReadStandardOutput()), this, SLOT(slot_readReplayStandardOutput()));
     connect(m_pVoglReplayProcess, SIGNAL(readyReadStandardError()), this, SLOT(slot_readReplayStandardError()));
 
+    connect(m_timeline, SIGNAL(timelineItemClicked(vogleditor_apiCallItem *)), this, SLOT(selectAPICallItem(vogleditor_apiCallItem *)));
+
     reset_tracefile_ui();
 }
 
@@ -2957,4 +2959,11 @@ void VoglEditor::on_contextComboBox_currentIndexChanged(int index)
 void VoglEditor::on_treeView_activated(const QModelIndex &index)
 {
     onApiCallSelected(index, true);
+}
+
+void VoglEditor::selectAPICallItem(vogleditor_apiCallItem *pItem)
+{
+    QModelIndexList hits = m_pApiCallTreeModel->match(m_pApiCallTreeModel->index(0, 0), Qt::UserRole, QVariant::fromValue((void*)pItem), 1, Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap);
+    if (hits.count() > 0)
+        selectApicallModelIndex(hits.at(0), true, true);
 }

--- a/src/vogleditor/vogleditor.h
+++ b/src/vogleditor/vogleditor.h
@@ -60,6 +60,7 @@ class vogleditor_QSnapshotOverlayWidget;
 class vogleditor_QTimelineView;
 class vogleditor_QVertexArrayExplorer;
 class vogleditor_QLaunchTracerDialog;
+class vogleditor_apiCallItem;
 
 class VoglEditor : public QMainWindow
 {
@@ -131,6 +132,8 @@ slots:
     void on_contextComboBox_currentIndexChanged(int index);
 
     void on_treeView_activated(const QModelIndex &index);
+
+    void selectAPICallItem(vogleditor_apiCallItem *pItem);
 
 private:
     Ui::VoglEditor *ui;

--- a/src/vogleditor/vogleditor.h
+++ b/src/vogleditor/vogleditor.h
@@ -45,6 +45,7 @@ class QModelIndex;
 class QProcess;
 class QProcessEnvironment;
 class QToolButton;
+class QScrollBar;
 class vogl_arb_program_state;
 class vogl_program_state;
 class vogleditor_apiCallTimelineModel;

--- a/src/vogleditor/vogleditor.h
+++ b/src/vogleditor/vogleditor.h
@@ -60,7 +60,7 @@ class vogleditor_QSnapshotOverlayWidget;
 class vogleditor_QTimelineView;
 class vogleditor_QVertexArrayExplorer;
 class vogleditor_QLaunchTracerDialog;
-class vogleditor_apiCallItem;
+class vogleditor_snapshotItem;
 
 class VoglEditor : public QMainWindow
 {
@@ -133,7 +133,7 @@ slots:
 
     void on_treeView_activated(const QModelIndex &index);
 
-    void selectAPICallItem(vogleditor_apiCallItem *pItem);
+    void selectAPICallItem(vogleditor_snapshotItem *pItem);
 
 private:
     Ui::VoglEditor *ui;

--- a/src/vogleditor/vogleditor.ui
+++ b/src/vogleditor/vogleditor.ui
@@ -39,7 +39,7 @@
        <widget class="QWidget" name="timelineLayoutWidget">
         <layout class="QVBoxLayout" name="timelineLayout" stretch="0">
          <property name="spacing">
-          <number>6</number>
+          <number>0</number>
          </property>
          <property name="sizeConstraint">
           <enum>QLayout::SetDefaultConstraint</enum>
@@ -49,6 +49,19 @@
          </property>
          <item>
           <widget class="QGraphicsView" name="timelineViewPlaceholder"/>
+         </item>
+         <item>
+          <widget class="QScrollBar" name="timelineScrollBar">
+           <property name="maximum">
+            <number>0</number>
+           </property>
+           <property name="singleStep">
+            <number>40</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -388,7 +401,7 @@
      <x>0</x>
      <y>0</y>
      <width>1025</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
@@ -158,6 +158,11 @@ float vogleditor_apiCallTimelineModel::u64ToFloat(uint64_t value)
     return static_cast<float>(value);
 }
 
+float vogleditor_apiCallTimelineModel::absoluteToRelativeTime(uint64_t time)
+{
+    return u64ToFloat(time - m_rawBaseTime);
+}
+
 unsigned int vogleditor_apiCallTimelineModel::randomRGB()
 {
 

--- a/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.cpp
@@ -47,8 +47,8 @@ void vogleditor_apiCallTimelineModel::refresh()
         return;
     }
 
-    float timelineStart = 0;
-    float timelineEnd = 1;
+    double timelineStart = 0;
+    double timelineEnd = 1;
     m_rawBaseTime = timelineStart;
 
     int numChildren = m_pRootApiCall->childCount();
@@ -64,8 +64,8 @@ void vogleditor_apiCallTimelineModel::refresh()
         pLastChild->frameItem()->getStartEndTimes(lastStart, lastEnd);
 
         m_rawBaseTime = firstStart;
-        timelineStart = u64ToFloat(firstStart - m_rawBaseTime);
-        timelineEnd = u64ToFloat(lastEnd - m_rawBaseTime);
+        timelineStart = firstStart - m_rawBaseTime;
+        timelineEnd = lastEnd - m_rawBaseTime;
     }
 
     // see if we actually have to update some of this stuff
@@ -90,14 +90,14 @@ void vogleditor_apiCallTimelineModel::refresh()
         m_rootItem = new vogleditor_timelineItem(timelineStart, timelineEnd);
 
         // add markers for the start of each frame
-        float frameStart = 0;
+        double frameStart = 0;
         for (int c = 0; c < numChildren; c++)
         {
             vogleditor_apiCallTreeItem *pFrameItem = m_pRootApiCall->child(c);
             if (pFrameItem->childCount() > 0)
             {
                 // add frame to root (root will manage deletion of frame object)
-                frameStart = u64ToFloat(pFrameItem->startTime() - m_rawBaseTime);
+                frameStart = pFrameItem->startTime() - m_rawBaseTime;
                 new vogleditor_timelineItem(frameStart, m_rootItem, pFrameItem->frameItem());
             }
             else
@@ -158,9 +158,9 @@ float vogleditor_apiCallTimelineModel::u64ToFloat(uint64_t value)
     return static_cast<float>(value);
 }
 
-float vogleditor_apiCallTimelineModel::absoluteToRelativeTime(uint64_t time)
+double vogleditor_apiCallTimelineModel::absoluteToRelativeTime(uint64_t time)
 {
-    return u64ToFloat(time - m_rawBaseTime);
+    return time - m_rawBaseTime;
 }
 
 unsigned int vogleditor_apiCallTimelineModel::randomRGB()
@@ -187,8 +187,8 @@ void vogleditor_apiCallTimelineModel::AddApiCallsToTimeline(vogleditor_apiCallTr
     {
         vogleditor_apiCallTreeItem *pChildCallTreeItem = pParentCallTreeItem->child(c);
 
-        float beginFloat = u64ToFloat(pChildCallTreeItem->startTime() - m_rawBaseTime);
-        float endFloat = u64ToFloat(pChildCallTreeItem->endTime() - m_rawBaseTime);
+        double beginFloat = pChildCallTreeItem->startTime() - m_rawBaseTime;
+        double endFloat = pChildCallTreeItem->endTime() - m_rawBaseTime;
 
         if (pChildCallTreeItem->isGroup())
         {

--- a/src/vogleditor/vogleditor_apicalltimelinemodel.h
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.h
@@ -36,7 +36,7 @@ class vogleditor_apiCallTimelineModel : public vogleditor_timelineModel
 public:
     explicit vogleditor_apiCallTimelineModel(vogleditor_apiCallTreeItem *pRootApiCall);
     void refresh();
-    float absoluteToRelativeTime(uint64_t time);
+    double absoluteToRelativeTime(uint64_t time);
 
 private:
     unsigned int randomRGB();

--- a/src/vogleditor/vogleditor_apicalltimelinemodel.h
+++ b/src/vogleditor/vogleditor_apicalltimelinemodel.h
@@ -36,6 +36,7 @@ class vogleditor_apiCallTimelineModel : public vogleditor_timelineModel
 public:
     explicit vogleditor_apiCallTimelineModel(vogleditor_apiCallTreeItem *pRootApiCall);
     void refresh();
+    float absoluteToRelativeTime(uint64_t time);
 
 private:
     unsigned int randomRGB();

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -623,6 +623,12 @@ QVariant vogleditor_QApiCallTreeModel::data(const QModelIndex &index, int role) 
         }
     }
 
+    //This allows QAbstractItemModel::match() to find the QModelIndex from the vogleditor_apiCallItem* it represents.
+    //Please note that this uses vogleditor_apiCallItem* and not vogleditor_apiCallTreeItem*.
+    //Using vogleditor_apiCallTreeItem* with QAbstractItemModel::match() will silently fail.
+    if (role == Qt::UserRole)
+        return QVariant::fromValue((void*)(pItem->apiCallItem()));
+
     return pItem->columnData(index.column(), role);
 }
 

--- a/src/vogleditor/vogleditor_qapicalltreemodel.cpp
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.cpp
@@ -624,10 +624,15 @@ QVariant vogleditor_QApiCallTreeModel::data(const QModelIndex &index, int role) 
     }
 
     //This allows QAbstractItemModel::match() to find the QModelIndex from the vogleditor_apiCallItem* it represents.
-    //Please note that this uses vogleditor_apiCallItem* and not vogleditor_apiCallTreeItem*.
+    //Please note that this uses vogleditor_snapshotItem* and not vogleditor_apiCallTreeItem*.
     //Using vogleditor_apiCallTreeItem* with QAbstractItemModel::match() will silently fail.
     if (role == Qt::UserRole)
-        return QVariant::fromValue((void*)(pItem->apiCallItem()));
+    {
+        if (pItem->isApiCall())
+            return QVariant::fromValue((void*)(pItem->apiCallItem()));
+        else if (pItem->isGroup())
+            return QVariant::fromValue((void*)(pItem->groupItem()));
+    }
 
     return pItem->columnData(index.column(), role);
 }

--- a/src/vogleditor/vogleditor_qtimelineview.cpp
+++ b/src/vogleditor/vogleditor_qtimelineview.cpp
@@ -120,14 +120,24 @@ void vogleditor_QTimelineView::wheelEvent(QWheelEvent *event)
     if (event->modifiers() & Qt::ControlModifier)
     {
         float oldZoom=m_zoom;
+        float oldScroll=m_scroll;
         if (event->angleDelta().y()>0)
             m_zoom=m_zoom*(1.2f);
         else
             m_zoom=m_zoom/(1.2f);
         m_zoom = qMax(m_zoom, 1.0f);
+
+        if ((long int)m_zoom*((long int)width())+(long int)m_gap*2 > 2147483647)
+        {
+            m_zoom=oldZoom;
+            return;
+        }
+
+        //Update the scrolol range in scroll bars before updating the scroll position.
         emit(scrollRangeChanged(0, m_zoom*width()-width()));
-        //Keep timeline stationary under the mouse:
-        scrollToPx(((m_scroll+event->x())/oldZoom)*m_zoom-event->x());
+
+        //Keep time line stationary under the mouse (using the oldScroll in case m_scroll was changes when updating the limits):
+        scrollToPx(((oldScroll+event->x())/oldZoom)*m_zoom-event->x());
     }else
     {
         scrollToPx(m_scroll-event->angleDelta().y()/3);

--- a/src/vogleditor/vogleditor_qtimelineview.cpp
+++ b/src/vogleditor/vogleditor_qtimelineview.cpp
@@ -95,8 +95,10 @@ void vogleditor_QTimelineView::mouseReleaseEvent(QMouseEvent *event)
     if (qAbs(event->pos().x()-m_mouseDragStartPos)<3)
     {
         vogleditor_timelineItem *pItem = itemUnderPos(event->pos());
-        if (pItem!=NULL)
+        if (pItem!=NULL && pItem->isApiCallItem())
             emit(timelineItemClicked(pItem->getApiCallItem()));
+        if (pItem!=NULL && pItem->isGroupItem())
+            emit(timelineItemClicked(pItem->getGroupItem()));
     }
 }
 
@@ -140,10 +142,22 @@ bool vogleditor_QTimelineView::event(QEvent *event)
         vogleditor_timelineItem* pItem = itemUnderPos(helpEvent->pos());
         if (pItem!=NULL)
         {
-            QString tip = QString::number(pItem->getApiCallItem()->globalCallIndex());
-            tip.append(": ");
-            tip.append(pItem->getApiCallItem()->apiFunctionCall());
-            QToolTip::showText(helpEvent->globalPos(), tip, this);
+            if (pItem->isApiCallItem())
+            {
+                QString tip = QString::number(pItem->getApiCallItem()->globalCallIndex());
+                tip.append(": ");
+                tip.append(pItem->getApiCallItem()->apiFunctionCall());
+                QToolTip::showText(helpEvent->globalPos(), tip, this);
+            }
+            else if(pItem->isGroupItem())
+            {
+                QString tip;
+                if (pItem->getGroupItem()->callCount()>1)
+                    tip = tr("%1 Calls").arg(QString::number(pItem->getGroupItem()->callCount()));
+                else
+                    tip = tr("1 Call");
+                QToolTip::showText(helpEvent->globalPos(), tip, this);
+            }
         } else {
             QToolTip::hideText();
             event->ignore();

--- a/src/vogleditor/vogleditor_qtimelineview.cpp
+++ b/src/vogleditor/vogleditor_qtimelineview.cpp
@@ -36,7 +36,8 @@ vogleditor_QTimelineView::vogleditor_QTimelineView(QWidget *parent)
       m_curFrame(0),
       m_curApiCallNumber(0),
       m_pModel(NULL),
-      m_pPixmap(NULL)
+      m_zoom(1),
+      m_scroll(0)
 {
     QLinearGradient gradient(QPointF(0, 1), QPointF(0, 0));
     gradient.setCoordinateMode(QGradient::ObjectBoundingMode);
@@ -49,7 +50,10 @@ vogleditor_QTimelineView::vogleditor_QTimelineView(QWidget *parent)
     gradient.setColorAt(1.0, QColor(0xa6, 0xce, 0x39));
     m_triangleBrushBlack = QBrush(gradient);
 
-    m_background = QBrush(QColor(200, 200, 200)); //QBrush(parent->palette().brush(parent->backgroundRole()));
+    QPalette Palette(palette());
+    Palette.setColor(QPalette::Background, QColor(200, 200, 200));
+    setAutoFillBackground(true);
+    setPalette(Palette);
     m_trianglePen = QPen(Qt::black);
     m_trianglePen.setWidth(1);
     m_trianglePen.setJoinStyle(Qt::MiterJoin);
@@ -63,32 +67,64 @@ vogleditor_QTimelineView::vogleditor_QTimelineView(QWidget *parent)
 
 vogleditor_QTimelineView::~vogleditor_QTimelineView()
 {
-    deletePixmap();
+
 }
 
 void vogleditor_QTimelineView::paintEvent(QPaintEvent *event)
 {
-    // Don't bother drawing if the rect is too small.
-    // For some reason this is happening at unexpected times.
-    int rectHeight = event->rect().height();
-    int rectWidth = event->rect().width();
-    if (rectHeight < 100 || rectWidth < 100)
-    {
-        return;
-    }
-
     QPainter painter;
     painter.begin(this);
     paint(&painter, event);
     painter.end();
 }
 
+void vogleditor_QTimelineView::mousePressEvent(QMouseEvent *event)
+{
+    if(event->buttons() & Qt::LeftButton)
+    {
+        m_mouseDragStartPos=event->x();
+        m_mouseDragStartScroll=m_scroll;
+    }
+}
+
+void vogleditor_QTimelineView::mouseMoveEvent(QMouseEvent *event)
+{
+    if(event->buttons() & Qt::LeftButton)
+    {
+        scrollToPx(m_mouseDragStartScroll+(m_mouseDragStartPos-event->x()));
+    }
+}
+
+void vogleditor_QTimelineView::wheelEvent(QWheelEvent *event)
+{
+    if (event->modifiers() & Qt::ControlModifier)
+    {
+        float oldZoom=m_zoom;
+        if (event->angleDelta().y()>0)
+            m_zoom=m_zoom*(1.2f);
+        else
+            m_zoom=m_zoom/(1.2f);
+        m_zoom = qMax(m_zoom, 1.0f);
+        //Keep timeline stationary under the mouse:
+        scrollToPx(((m_scroll+event->x())/oldZoom)*m_zoom-event->x());
+    }else
+    {
+        scrollToPx(m_scroll-=event->angleDelta().y()/3);
+    }
+}
+
+
+void vogleditor_QTimelineView::scrollToPx(int scroll)
+{
+    m_scroll=scroll;
+    m_scroll=qMax(m_scroll, 0.0f);
+    m_scroll=qMin(m_scroll, m_zoom*width()-width());
+    update();
+}
+
 void vogleditor_QTimelineView::drawBaseTimeline(QPainter *painter, const QRect &rect, int gap)
 {
     painter->save();
-
-    // fill entire background with background color
-    painter->fillRect(rect, m_background);
 
     // translate drawing to vertical center of rect
     painter->translate(0, rect.height() / 2);
@@ -100,8 +136,7 @@ void vogleditor_QTimelineView::drawBaseTimeline(QPainter *painter, const QRect &
     painter->translate(gap, 0);
 
     // draw the actual timeline
-    int lineLength = rect.width() - 2 * gap;
-    painter->drawLine(0, 0, lineLength, 0);
+    painter->drawLine(0, 0, m_lineLength, 0);
 
     painter->restore();
 }
@@ -110,15 +145,16 @@ void vogleditor_QTimelineView::paint(QPainter *painter, QPaintEvent *event)
 {
     int gap = 10;
     int arrowHeight = 10;
-    int arrowTop = event->rect().height() / 2 - gap - arrowHeight;
+    int arrowTop = height() / 2 - gap - arrowHeight;
     int arrowHalfWidth = 3;
-    m_lineLength = event->rect().width() - 2 * gap;
+    m_lineLength = width()*m_zoom - 2 * gap;
 
     QPolygon triangle(3);
     triangle.setPoint(0, 0, arrowTop);
     triangle.setPoint(1, -arrowHalfWidth, arrowTop + arrowHeight);
     triangle.setPoint(2, arrowHalfWidth, arrowTop + arrowHeight);
 
+    painter->translate(-m_scroll, 0);
     drawBaseTimeline(painter, event->rect(), gap);
 
     if (m_pModel == NULL)
@@ -131,56 +167,26 @@ void vogleditor_QTimelineView::paint(QPainter *painter, QPaintEvent *event)
         return;
     }
 
-    if (m_pPixmap != NULL)
-    {
-        int rectHeight = event->rect().height();
-        int rectWidth = event->rect().width();
-        int pmHeight = m_pPixmap->height();
-        int pmWidth = m_pPixmap->width();
-
-        float widthPctDelta = (float)(rectWidth - pmWidth) / (float)pmWidth;
-        float heightPctDelta = (float)(rectHeight - pmHeight) / (float)pmHeight;
-
-        // If the resize is of a 'signficant' amount, then delete the pixmap so that it will be regenerated at the new size.
-        if (fabs(widthPctDelta) > 0.2 ||
-            fabs(heightPctDelta) > 0.2)
-        {
-            deletePixmap();
-        }
-    }
-
-    if (m_pPixmap == NULL)
-    {
-        m_pPixmap = new QPixmap(event->rect().width(), event->rect().height());
-        QPainter pixmapPainter(m_pPixmap);
-        drawBaseTimeline(&pixmapPainter, event->rect(), gap);
-
-        // translate drawing to vertical center of rect
-        // everything will have a small gap on the left and right sides
-        pixmapPainter.translate(gap, event->rect().height() / 2);
-
-        m_horizontalScale = (float)m_lineLength / (float)m_pModel->get_root_item()->getDuration();
-
-        // we don't want to draw the root item, but all of its children
-        int numChildren = m_pModel->get_root_item()->childCount();
-        int height = event->rect().height() / 2 - 2 * gap;
-
-        pixmapPainter.setBrush(m_triangleBrushWhite);
-        pixmapPainter.setPen(m_trianglePen);
-
-        float minimumOffset = 0;
-        for (int c = 0; c < numChildren; c++)
-        {
-            vogleditor_timelineItem *pChild = m_pModel->get_root_item()->child(c);
-            drawTimelineItem(&pixmapPainter, pChild, height, minimumOffset);
-        }
-    }
-
-    painter->drawPixmap(event->rect(), *m_pPixmap, m_pPixmap->rect());
-
     // translate drawing to vertical center of rect
     // everything will have a small gap on the left and right sides
-    painter->translate(gap, event->rect().height() / 2);
+    painter->translate(gap, height() / 2);
+
+    m_horizontalScale = (float)m_lineLength / (float)m_pModel->get_root_item()->getDuration();
+
+    // we don't want to draw the root item, but all of its children
+    int numChildren = m_pModel->get_root_item()->childCount();
+    int i_height = height() / 2 - 2 * gap;
+
+    painter->setBrush(m_triangleBrushWhite);
+    painter->setPen(m_trianglePen);
+
+    float minimumOffset = 0;
+    vogleditor_timelineItem *rootItem = m_pModel->get_root_item();
+    for (int c = 0; c < numChildren; c++)
+    {
+        vogleditor_timelineItem *pChild = rootItem->child(c);
+        drawTimelineItem(painter, pChild, i_height, minimumOffset);
+    }
 
     painter->setBrush(m_triangleBrushWhite);
     painter->setPen(m_trianglePen);
@@ -188,10 +194,9 @@ void vogleditor_QTimelineView::paint(QPainter *painter, QPaintEvent *event)
     bool bFoundFrame = false;
     bool bFoundApiCall = false;
 
-    int numChildren = m_pModel->get_root_item()->childCount();
     for (int c = 0; c < numChildren; c++)
     {
-        vogleditor_timelineItem *pChild = m_pModel->get_root_item()->child(c);
+        vogleditor_timelineItem *pChild = rootItem->child(c);
 
         // draw current frame marker
         if (bFoundFrame == false && pChild->getFrameItem() != NULL && pChild->getFrameItem()->frameNumber() == m_curFrame)
@@ -284,8 +289,6 @@ void vogleditor_QTimelineView::drawTimelineItem(QPainter *painter, vogleditor_ti
     {
         return;
     }
-
-    painter->save();
     if (pItem->isMarker()) // frame marker
     {
         painter->setBrush(m_triangleBrushWhite);
@@ -296,10 +299,11 @@ void vogleditor_QTimelineView::drawTimelineItem(QPainter *painter, vogleditor_ti
     }
     else
     {
-        // only draw if the item will extend beyond the minimum offset
+        // only draw if the item will extend beyond the minimum offset and it is on-screen
         float leftOffset = scalePositionHorizontally(pItem->getBeginTime());
         float scaledWidth = scaleDurationHorizontally(duration);
-        if (minimumOffset < leftOffset + scaledWidth)
+        float rightOffset = leftOffset + scaledWidth;
+        if (minimumOffset < rightOffset && rightOffset>m_scroll && leftOffset<m_scroll+width() )
         {
             // Set brush fill color
             if (pItem->getBrush())
@@ -353,5 +357,4 @@ void vogleditor_QTimelineView::drawTimelineItem(QPainter *painter, vogleditor_ti
         }
     }
 
-    painter->restore();
 }

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -116,15 +116,15 @@ private:
     QPen m_trianglePen;
     QPen m_textPen;
     QFont m_textFont;
-    float m_roundoff;
+    double m_roundoff;
     float m_horizontalScale;
     int m_lineLength;
     uint64_t m_firstCallTime;
-    float m_curFrameTime;
-    float m_curApiCallTime;
+    double m_curFrameTime;
+    double m_curApiCallTime;
     float m_maxItemDuration;
     float m_zoom;
-    float m_scroll;
+    int m_scroll;
     int m_mouseDragStartPos;
     int m_mouseDragStartScroll;
     QScrollBar *m_scrollBar;
@@ -134,17 +134,17 @@ private:
     QPixmap *m_pPixmap;
 
     void drawBaseTimeline(QPainter *painter, const QRect &rect, int gap);
-    void drawTimelineItem(QPainter *painter, vogleditor_timelineItem *pItem, int height, float &minimumOffset);
+    void drawTimelineItem(QPainter *painter, vogleditor_timelineItem *pItem, int height, double &minimumOffset);
 
-    float scaleDurationHorizontally(float value);
-    float scalePositionHorizontally(float value);
+    double scaleDurationHorizontally(double value);
+    double scalePositionHorizontally(double value);
     vogleditor_timelineItem* itemUnderPos(QPoint pos);
 
     struct timelineItemPos
     {
         vogleditor_timelineItem *pItem;
-        float leftOffset;
-        float rightOffset;
+        int leftOffset;
+        int rightOffset;
     };
     QLinkedList<timelineItemPos> m_timelineItemPosCache;
 public slots:

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -37,6 +37,7 @@ QT_END_NAMESPACE
 #include <QBrush>
 #include <QFont>
 #include <QPen>
+#include <QLinkedList>
 
 #include "vogleditor_timelinemodel.h"
 #include "vogleditor_timelineitem.h"
@@ -99,6 +100,7 @@ private:
     int m_mouseDragStartPos;
     int m_mouseDragStartScroll;
     QScrollBar *m_scrollBar;
+    int m_gap;
 
     vogleditor_timelineModel *m_pModel;
 
@@ -108,20 +110,30 @@ private:
 
     float scaleDurationHorizontally(float value);
     float scalePositionHorizontally(float value);
+    vogleditor_timelineItem* itemUnderPos(QPoint pos);
+
+    struct timelineItemPos
+    {
+        vogleditor_timelineItem *pItem;
+        float leftOffset;
+        float rightOffset;
+    };
+    QLinkedList<timelineItemPos> m_timelineItemPosCache;
 public slots:
     void scrollToPx(int scroll);
     void resetZoom();
 protected:
     void paintEvent(QPaintEvent *event);
     void mousePressEvent(QMouseEvent *event);
+    void mouseReleaseEvent(QMouseEvent *event);
     void wheelEvent(QWheelEvent * event);    
     void mouseMoveEvent(QMouseEvent *event);
     void resizeEvent(QResizeEvent *);
+    bool event(QEvent *event);
 signals:
     void scrollRangeChanged(int min, int max);
     void scrollPosChanged(int pos);
-public
-slots:
+    void timelineItemClicked(vogleditor_apiCallItem *pItem);
 };
 
 #endif // VOGLEDITOR_QTIMELINEVIEW_H

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -44,6 +44,8 @@ QT_END_NAMESPACE
 
 static const float cVOGL_TIMELINEOFFSET = 0.085f;
 
+class vogleditor_snapshotItem;
+
 class vogleditor_QTimelineView : public QWidget
 {
     Q_OBJECT
@@ -133,7 +135,7 @@ protected:
 signals:
     void scrollRangeChanged(int min, int max);
     void scrollPosChanged(int pos);
-    void timelineItemClicked(vogleditor_apiCallItem *pItem);
+    void timelineItemClicked(vogleditor_snapshotItem *pItem);
 };
 
 #endif // VOGLEDITOR_QTIMELINEVIEW_H

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -65,8 +65,12 @@ public:
         m_curFrameTime=-1;
         m_curApiCallTime=-1;
 
-        m_pModel = pModel;
-        if (m_pModel != NULL)
+        m_pModel = pModel;        
+        if (m_pModel == NULL)
+        {
+            deletePixmap();
+        }
+        else
         {
             m_maxItemDuration = m_pModel->get_root_item()->getMaxChildDuration();
             if (m_pModel->get_root_item()->isGroupItem())
@@ -96,7 +100,16 @@ public:
         if (m_pModel != NULL)
             m_curApiCallTime=m_pModel->absoluteToRelativeTime(apiCall->startTime());
     }
-    
+
+    void deletePixmap()
+    {
+        if (m_pPixmap != NULL)
+        {
+            delete m_pPixmap;
+            m_pPixmap = NULL;
+        }
+    }
+
 private:
     QBrush m_triangleBrushWhite;
     QBrush m_triangleBrushBlack;
@@ -118,6 +131,7 @@ private:
     int m_gap;
 
     vogleditor_apiCallTimelineModel *m_pModel;
+    QPixmap *m_pPixmap;
 
     void drawBaseTimeline(QPainter *painter, const QRect &rect, int gap);
     void drawTimelineItem(QPainter *painter, vogleditor_timelineItem *pItem, int height, float &minimumOffset);

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -31,6 +31,7 @@
 QT_BEGIN_NAMESPACE
 class QPainter;
 class QPaintEvent;
+class QScrollBar;
 QT_END_NAMESPACE
 
 #include <QBrush>
@@ -50,6 +51,7 @@ public:
     virtual ~vogleditor_QTimelineView();
 
     void paint(QPainter *painter, QPaintEvent *event);
+    void setScrollBar(QScrollBar *scrollBar);
 
     inline void setModel(vogleditor_timelineModel *pModel)
     {
@@ -96,6 +98,7 @@ private:
     float m_scroll;
     int m_mouseDragStartPos;
     int m_mouseDragStartScroll;
+    QScrollBar *m_scrollBar;
 
     vogleditor_timelineModel *m_pModel;
 
@@ -105,16 +108,18 @@ private:
 
     float scaleDurationHorizontally(float value);
     float scalePositionHorizontally(float value);
-
+public slots:
     void scrollToPx(int scroll);
+    void resetZoom();
 protected:
     void paintEvent(QPaintEvent *event);
     void mousePressEvent(QMouseEvent *event);
     void wheelEvent(QWheelEvent * event);    
     void mouseMoveEvent(QMouseEvent *event);
-
+    void resizeEvent(QResizeEvent *);
 signals:
-
+    void scrollRangeChanged(int min, int max);
+    void scrollPosChanged(int pos);
 public
 slots:
 };

--- a/src/vogleditor/vogleditor_qtimelineview.h
+++ b/src/vogleditor/vogleditor_qtimelineview.h
@@ -54,11 +54,7 @@ public:
     inline void setModel(vogleditor_timelineModel *pModel)
     {
         m_pModel = pModel;
-        if (m_pModel == NULL)
-        {
-            deletePixmap();
-        }
-        else
+        if (m_pModel != NULL)
         {
             m_maxItemDuration = m_pModel->get_root_item()->getMaxChildDuration();
         }
@@ -84,17 +80,7 @@ public:
         m_curApiCallNumber = apiCallNumber;
     }
 
-    void deletePixmap()
-    {
-        if (m_pPixmap != NULL)
-        {
-            delete m_pPixmap;
-            m_pPixmap = NULL;
-        }
-    }
-
 private:
-    QBrush m_background;
     QBrush m_triangleBrushWhite;
     QBrush m_triangleBrushBlack;
     QPen m_trianglePen;
@@ -106,9 +92,12 @@ private:
     unsigned long long m_curFrame;
     unsigned long long m_curApiCallNumber;
     float m_maxItemDuration;
+    float m_zoom;
+    float m_scroll;
+    int m_mouseDragStartPos;
+    int m_mouseDragStartScroll;
 
     vogleditor_timelineModel *m_pModel;
-    QPixmap *m_pPixmap;
 
     void drawBaseTimeline(QPainter *painter, const QRect &rect, int gap);
     void drawTimelineItem(QPainter *painter, vogleditor_timelineItem *pItem, int height, float &minimumOffset);
@@ -117,8 +106,12 @@ private:
     float scaleDurationHorizontally(float value);
     float scalePositionHorizontally(float value);
 
+    void scrollToPx(int scroll);
 protected:
     void paintEvent(QPaintEvent *event);
+    void mousePressEvent(QMouseEvent *event);
+    void wheelEvent(QWheelEvent * event);    
+    void mouseMoveEvent(QMouseEvent *event);
 
 signals:
 

--- a/src/vogleditor/vogleditor_timelineitem.cpp
+++ b/src/vogleditor/vogleditor_timelineitem.cpp
@@ -29,7 +29,7 @@
 #include "vogl_common.h"
 
 // Timeline root (fullspan)
-vogleditor_timelineItem::vogleditor_timelineItem(float begin, float end)
+vogleditor_timelineItem::vogleditor_timelineItem(double begin, double end)
     : m_brush(NULL),
       m_beginTime(begin),
       m_endTime(end),
@@ -44,7 +44,7 @@ vogleditor_timelineItem::vogleditor_timelineItem(float begin, float end)
 }
 
 // Timeline markers (frame demarcations)
-vogleditor_timelineItem::vogleditor_timelineItem(float time, vogleditor_timelineItem *parent, vogleditor_frameItem *frameItem)
+vogleditor_timelineItem::vogleditor_timelineItem(double time, vogleditor_timelineItem *parent, vogleditor_frameItem *frameItem)
     : m_brush(NULL),
       m_beginTime(time),
       m_endTime(time),
@@ -61,7 +61,7 @@ vogleditor_timelineItem::vogleditor_timelineItem(float time, vogleditor_timeline
 }
 
 // Timeline groups
-vogleditor_timelineItem::vogleditor_timelineItem(float begin, float end, vogleditor_timelineItem *parent, vogleditor_groupItem *groupItem)
+vogleditor_timelineItem::vogleditor_timelineItem(double begin, double end, vogleditor_timelineItem *parent, vogleditor_groupItem *groupItem)
     : m_brush(NULL),
       m_beginTime(begin),
       m_endTime(end),
@@ -78,7 +78,7 @@ vogleditor_timelineItem::vogleditor_timelineItem(float begin, float end, vogledi
 }
 
 // Timeline segmented spans
-vogleditor_timelineItem::vogleditor_timelineItem(float begin, float end, vogleditor_timelineItem *parent, vogleditor_apiCallItem *apiCallItem)
+vogleditor_timelineItem::vogleditor_timelineItem(double begin, double end, vogleditor_timelineItem *parent, vogleditor_apiCallItem *apiCallItem)
     : m_brush(NULL),
       m_beginTime(begin),
       m_endTime(end),
@@ -175,17 +175,17 @@ void vogleditor_timelineItem::setBrush(QBrush *brush)
     m_brush = brush;
 }
 
-float vogleditor_timelineItem::getBeginTime() const
+double vogleditor_timelineItem::getBeginTime() const
 {
     return m_beginTime;
 }
 
-float vogleditor_timelineItem::getEndTime() const
+double vogleditor_timelineItem::getEndTime() const
 {
     return m_endTime;
 }
 
-float vogleditor_timelineItem::getDuration() const
+double vogleditor_timelineItem::getDuration() const
 {
     return m_duration;
 }
@@ -200,7 +200,7 @@ bool vogleditor_timelineItem::isMarker() const
     return !m_isSpan;
 }
 
-float vogleditor_timelineItem::getMaxChildDuration() const
+double vogleditor_timelineItem::getMaxChildDuration() const
 {
     return m_maxChildDuration;
 }

--- a/src/vogleditor/vogleditor_timelineitem.h
+++ b/src/vogleditor/vogleditor_timelineitem.h
@@ -36,10 +36,10 @@ class vogleditor_apiCallItem;
 class vogleditor_timelineItem
 {
 public:
-    vogleditor_timelineItem(float begin, float end);
-    vogleditor_timelineItem(float time, vogleditor_timelineItem *parent, vogleditor_frameItem *groupItem);
-    vogleditor_timelineItem(float begin, float end, vogleditor_timelineItem *parent, vogleditor_groupItem *groupItem);
-    vogleditor_timelineItem(float begin, float end, vogleditor_timelineItem *parent, vogleditor_apiCallItem *apiCallItem);
+    vogleditor_timelineItem(double begin, double end);
+    vogleditor_timelineItem(double time, vogleditor_timelineItem *parent, vogleditor_frameItem *groupItem);
+    vogleditor_timelineItem(double begin, double end, vogleditor_timelineItem *parent, vogleditor_groupItem *groupItem);
+    vogleditor_timelineItem(double begin, double end, vogleditor_timelineItem *parent, vogleditor_apiCallItem *apiCallItem);
     ~vogleditor_timelineItem();
 
     void appendChild(vogleditor_timelineItem *child);
@@ -53,11 +53,11 @@ public:
 
     void setBrush(QBrush *brush);
 
-    float getBeginTime() const;
-    float getEndTime() const;
-    float getDuration() const;
+    double getBeginTime() const;
+    double getEndTime() const;
+    double getDuration() const;
 
-    float getMaxChildDuration() const;
+    double getMaxChildDuration() const;
 
     bool isSpan() const;
     bool isMarker() const;
@@ -95,11 +95,11 @@ public:
 
 private:
     QBrush *m_brush;
-    float m_beginTime;
-    float m_endTime;
-    float m_duration;
+    double m_beginTime;
+    double m_endTime;
+    double m_duration;
     bool m_isSpan;
-    float m_maxChildDuration;
+    double m_maxChildDuration;
 
     QList<vogleditor_timelineItem *> m_childItems;
 


### PR DESCRIPTION
Added zoom and scroll support to QTimelineView. Use Ctrl+wheel to zoom and wheel, drag time line or use scrollbar to scroll.
Items on the time line can now be clicked to display the matching API call or group in the call tree view.
Hovering over an item in the time line displays a tool tip with the call number, name and parameters of the call.
This implements the features requested in Issue #110.