### PR TITLE
Vertex visualizer

### DIFF
--- a/src/vogleditor/CMakeLists.txt
+++ b/src/vogleditor/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SRC_LIST
     vogleditor_qtrimdialog.cpp
     vogleditor_qdumpdialog.cpp
     vogleditor_qvertexarrayexplorer.cpp
+    vogleditor_qvertexvisualizer.cpp
     vogleditor_output.cpp
     vogleditor_statetreearbprogramitem.cpp
     vogleditor_statetreearbprogramenvitem.cpp
@@ -105,6 +106,7 @@ set(UI_HEADER_LIST
     vogleditor_qtrimdialog.h
     vogleditor_qdumpdialog.h
     vogleditor_qvertexarrayexplorer.h
+    vogleditor_qvertexvisualizer.h
    )
 
 # these are for non-QOBJECT headers

--- a/src/vogleditor/vogleditor.cpp
+++ b/src/vogleditor/vogleditor.cpp
@@ -2287,14 +2287,18 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
     }
 
     gl_entrypoint_id_t callId = (gl_entrypoint_id_t)pApiCall->apiCallItem()->getGLPacket()->m_entrypoint_id;
-    vogl_trace_packet &trace_packet = *(pApiCall->apiCallItem()->getTracePacket());
+    vogl_trace_packet &trace_packet = *(pApiCall->apiCallItem()->getTracePacket());    
+
+    //This is used to tell the visulizer how to render
+    GLenum drawMode = trace_packet.get_param_value<GLsizei>(0);
 
     if (callId == VOGL_ENTRYPOINT_glDrawElements)
     {
         GLsizei count = trace_packet.get_param_value<GLsizei>(1);
         GLenum type = trace_packet.get_param_value<GLenum>(2);
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(3);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0, drawMode);
+
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawRangeElements ||
              callId == VOGL_ENTRYPOINT_glDrawRangeElementsEXT)
@@ -2302,7 +2306,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLsizei count = trace_packet.get_param_value<GLsizei>(3);
         GLenum type = trace_packet.get_param_value<GLenum>(4);
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(5);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawElementsInstancedBaseVertex)
     {
@@ -2311,7 +2315,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(3);
         GLsizei primcount = trace_packet.get_param_value<GLsizei>(4);
         GLint basevertex = trace_packet.get_param_value<GLint>(5);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawRangeElementsBaseVertex)
     {
@@ -2319,7 +2323,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLenum type = trace_packet.get_param_value<GLenum>(4);
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(5);
         GLint basevertex = trace_packet.get_param_value<GLint>(6);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawElementsBaseVertex)
     {
@@ -2327,7 +2331,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLenum type = trace_packet.get_param_value<GLenum>(2);
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(3);
         GLint basevertex = trace_packet.get_param_value<GLint>(4);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), 0, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawArraysInstanced ||
              callId == VOGL_ENTRYPOINT_glDrawArraysInstancedEXT ||
@@ -2336,14 +2340,14 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLint first = trace_packet.get_param_value<GLsizei>(1);
         GLsizei count = trace_packet.get_param_value<GLsizei>(2);
         GLsizei primcount = trace_packet.get_param_value<GLsizei>(3);
-        m_pVertexArrayExplorer->set_element_array_options(count, GL_NONE, 0, first, NULL, primcount, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, GL_NONE, 0, first, NULL, primcount, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawArrays ||
              callId == VOGL_ENTRYPOINT_glDrawArraysEXT)
     {
         GLint first = trace_packet.get_param_value<GLsizei>(1);
         GLsizei count = trace_packet.get_param_value<GLsizei>(2);
-        m_pVertexArrayExplorer->set_element_array_options(count, GL_NONE, 0, first, NULL, 0, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, GL_NONE, 0, first, NULL, 0, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawElementsInstanced ||
              callId == VOGL_ENTRYPOINT_glDrawElementsInstancedARB ||
@@ -2353,7 +2357,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLenum type = trace_packet.get_param_value<GLenum>(2);
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(3);
         GLsizei primcount = trace_packet.get_param_value<GLsizei>(4);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, 0);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, 0, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawElementsInstancedBaseVertexBaseInstance)
     {
@@ -2363,7 +2367,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLsizei primcount = trace_packet.get_param_value<GLsizei>(4);
         GLint basevertex = trace_packet.get_param_value<GLint>(5);
         GLuint baseinstance = trace_packet.get_param_value<GLuint>(6);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, baseinstance);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, basevertex, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, baseinstance, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawArraysInstancedBaseInstance)
     {
@@ -2371,7 +2375,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         GLsizei count = trace_packet.get_param_value<GLsizei>(2);
         GLsizei primcount = trace_packet.get_param_value<GLsizei>(3);
         GLuint baseinstance = trace_packet.get_param_value<GLuint>(4);
-        m_pVertexArrayExplorer->set_element_array_options(count, GL_NONE, 0, first, NULL, primcount, baseinstance);
+        m_pVertexArrayExplorer->set_element_array_options(count, GL_NONE, 0, first, NULL, primcount, baseinstance, drawMode);
     }
     else if (callId == VOGL_ENTRYPOINT_glDrawElementsInstancedBaseInstance)
     {
@@ -2380,7 +2384,7 @@ void VoglEditor::update_vertex_array_explorer_for_apicall(vogleditor_apiCallTree
         vogl_trace_ptr_value trace_indices_ptr_value = trace_packet.get_param_ptr_value(3);
         GLsizei primcount = trace_packet.get_param_value<GLsizei>(4);
         GLuint baseinstance = trace_packet.get_param_value<GLuint>(5);
-        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, baseinstance);
+        m_pVertexArrayExplorer->set_element_array_options(count, type, (uint32_t)trace_indices_ptr_value, 0, trace_packet.get_key_value_map().get_blob(string_hash("indices")), primcount, baseinstance, drawMode);
     }
     //TODO
     //    else if (callId == VOGL_ENTRYPOINT_glMultiDrawArrays ||

--- a/src/vogleditor/vogleditor_qvertexarrayexplorer.cpp
+++ b/src/vogleditor/vogleditor_qvertexarrayexplorer.cpp
@@ -727,13 +727,13 @@ void vogleditor_QVertexArrayExplorer::update_array_table_headers()
     {
         // no instanced vertex data, so collapse the view
         QList<int> sizes;
-        sizes << 1 << 0;
+        sizes << 1 << 1 << 0;
         ui->splitter->setSizes(sizes);
     }
     else
     {
         QList<int> sizes;
-        sizes << 1 << 1;
+        sizes << 1 << 1 << 1;
         ui->splitter->setSizes(sizes);
     }
 }
@@ -821,25 +821,20 @@ void vogleditor_QVertexArrayExplorer::update_vertex_array_visualizations()
             attrib_buffers_to_render.push_back(b);
         }
     }
-
-//    vogleditor_output_message((QString::number(attrib_buffers_to_render.size()).append(" attrib_buffers found. ").append(QString::number(vertexVisualizers.size()))).toLocal8Bit());
-
     //Ensure we have the correct number of vertexVisualizers.
     if (m_vertexVisualizers.size()<attrib_buffers_to_render.size())
     {
         for (uint b = m_vertexVisualizers.size(); b < attrib_buffers_to_render.size(); b++)
         {
-//            vogleditor_output_message("Adding vis.");
             vogleditor_QVertexVisualizer *vis = new vogleditor_QVertexVisualizer(this);
             m_vertexVisualizers.push_back(vis);
-            ui->horizontalLayout_3->addWidget(vis);
+            ui->vertexVisualizersLayout->addWidget(vis);
         }
     }
     else if (m_vertexVisualizers.size()>attrib_buffers_to_render.size())
     {
         for (uint b = m_vertexVisualizers.size(); b > attrib_buffers_to_render.size(); b--)
         {
-//            vogleditor_output_message("Deleting vis.");
             m_vertexVisualizers.at(b-1)->deleteLater();
             m_vertexVisualizers.pop_back();
         }

--- a/src/vogleditor/vogleditor_qvertexarrayexplorer.h
+++ b/src/vogleditor/vogleditor_qvertexarrayexplorer.h
@@ -4,12 +4,17 @@
 #include <QWidget>
 #include "vogl_core.h"
 #include "gl_types.h"
+#include "vogleditor_output.h"
+#include <QVector3D>
+
 class vogl_buffer_state;
 class vogl_context_snapshot;
 class vogl_vao_state;
 class vogl_gl_object_state;
 typedef vogl::vector<vogl_gl_object_state *> vogl_gl_object_state_ptr_vec;
 struct vogl_vertex_attrib_desc;
+
+class vogleditor_QVertexVisualizer;
 
 namespace Ui
 {
@@ -33,7 +38,7 @@ public:
     // This is intended to only by called by an external object to set the UI.
     // Since these values are (ideally) set based on the current API call, we should not automatically update the UI after these are set.
     // However, the user may manually change the settings in the UI; that's fine.
-    void set_element_array_options(uint32_t count, GLenum type, uint32_t byteOffset, int32_t baseVertex, vogl::uint8_vec *pClientSideElements, uint32_t instanceCount, uint32_t baseInstance);
+    void set_element_array_options(uint32_t count, GLenum type, uint32_t byteOffset, int32_t baseVertex, vogl::uint8_vec *pClientSideElements, uint32_t instanceCount, uint32_t baseInstance, GLenum drawMode);
 
     void beginUpdate()
     {
@@ -82,6 +87,7 @@ private:
     const vogl::uint8_vec *m_currentCallElementIndices;
     uint32_t m_currentCallInstanceCount;
     uint32_t m_currentCallBaseInstance;
+    GLenum m_currentCallDrawMode;
 
     void auto_update_element_count();
 
@@ -93,9 +99,13 @@ private:
     void update_array_table_headers();
     void update_vertex_array_table();
     void update_instance_array_table();
+    void update_vertex_array_visualizations();
 
     bool calculate_element_and_format_as_string(const vogl::uint8_vec *pElementArray, uint32_t index, int typeIndex, int byteOffset, int baseVertex, uint32_t &elementValue, QString &elementString);
     QString format_buffer_data_as_string(uint32_t index, const vogl_buffer_state &bufferState, const vogl_vertex_attrib_desc &attribDesc);
+
+    vogl::vector<vogleditor_QVertexVisualizer*> m_vertexVisualizers;
+    QVector3D buffer_data_to_QVector3D(uint32_t index, const vogl_buffer_state &bufferState, const vogl_vertex_attrib_desc &attribDesc);
 };
 
 #endif // VOGLEDITOR_QVERTEXARRAYEXPLORER_H

--- a/src/vogleditor/vogleditor_qvertexarrayexplorer.ui
+++ b/src/vogleditor/vogleditor_qvertexarrayexplorer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>655</width>
-    <height>405</height>
+    <width>551</width>
+    <height>617</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -79,30 +79,86 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <widget class="QScrollArea" name="scrollArea">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>150</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>150</height>
+       </size>
+      </property>
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOn</enum>
+      </property>
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>531</width>
+         <height>134</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="vertexVisualizersLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+         </layout>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>614</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
      <widget class="QTableWidget" name="vertexTableWidget">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/vogleditor/vogleditor_qvertexarrayexplorer.ui
+++ b/src/vogleditor/vogleditor_qvertexarrayexplorer.ui
@@ -79,6 +79,26 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/vogleditor/vogleditor_qvertexvisualizer.cpp
+++ b/src/vogleditor/vogleditor_qvertexvisualizer.cpp
@@ -47,10 +47,15 @@ void vogleditor_QVertexVisualizer::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
     painter.drawText(QRectF(0, 0, width(), height()), Qt::AlignCenter | Qt::AlignBottom , m_label);
-
     painter.save();
-    painter.scale(height()/2,-height()/2);
-    painter.translate(1.0f*((float)width()/(float)height()),-1);
+    int textheight;
+    if (isWindow())
+        textheight=0;
+    else
+        textheight = painter.fontMetrics().height();
+    float viewPortHeight = height()-textheight;
+    painter.scale(viewPortHeight/2,-viewPortHeight/2);
+    painter.translate(1.0f*((float)width()/viewPortHeight),-1);
     QPen pen = painter.pen();
     pen.setWidth(0);
     painter.setPen(pen);

--- a/src/vogleditor/vogleditor_qvertexvisualizer.cpp
+++ b/src/vogleditor/vogleditor_qvertexvisualizer.cpp
@@ -39,7 +39,6 @@ void vogleditor_QVertexVisualizer::setVertices(QVector<QVector3D> vertices)
         maxValue=qMax(maxValue, qAbs(vertex.y()));
         maxValue=qMax(maxValue, qAbs(vertex.z()));
     }
-    vogleditor_output_message(QString::number(maxValue).toLocal8Bit());
     m_projection->setToIdentity();
     m_projection->ortho(-maxValue,maxValue,-maxValue,maxValue,-maxValue,maxValue);
 }
@@ -132,6 +131,11 @@ void vogleditor_QVertexVisualizer::paintEvent(QPaintEvent *event)
         painter.restore();
         painter.drawText(QRectF(0, 0, width(), height()), Qt::AlignCenter | Qt::AlignVCenter , "Draw mode\nnot supported\nby visualizer.");
     }
+    if (!isWindow())
+    {
+        painter.setPen(QColor(160,160,160));
+        painter.drawLine(width()-1, 0, width()-1, height());
+    }
 }
 
 void vogleditor_QVertexVisualizer::mousePressEvent(QMouseEvent *event)
@@ -150,7 +154,7 @@ void vogleditor_QVertexVisualizer::mouseMoveEvent(QMouseEvent *event)
         setXRotation(m_xRot - 8 * dy);
         setYRotation(m_yRot - 8 * dx);
         m_lastPos = event->pos();
-   }
+    }
 }
 
 void vogleditor_QVertexVisualizer::showContextMenu(const QPoint &pos)

--- a/src/vogleditor/vogleditor_qvertexvisualizer.cpp
+++ b/src/vogleditor/vogleditor_qvertexvisualizer.cpp
@@ -70,7 +70,33 @@ void vogleditor_QVertexVisualizer::paintEvent(QPaintEvent *event)
         transformedVertices.push_back((VPMatrix*vertex).toVector2D().toPointF());
     }
     //TODO Support more drawing modes.
-    if (m_draw_mode==GL_LINE_STRIP)
+    if (m_draw_mode==GL_TRIANGLES){
+        for (int i =0; i<transformedVertices.size()/3; i++)
+        {
+            int j=i*3;
+            painter.drawLine(transformedVertices[j],transformedVertices[j+1]);
+            painter.drawLine(transformedVertices[j+1],transformedVertices[j+2]);
+            painter.drawLine(transformedVertices[j+2],transformedVertices[j]);
+        }
+        painter.restore();
+    }else if (m_draw_mode==GL_TRIANGLE_STRIP){
+        for (int i =0; i<transformedVertices.size()-2; i=i+1)
+        {
+            painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
+            painter.drawLine(transformedVertices[i+2],transformedVertices[i]);
+        }
+        if(transformedVertices.size()>3)
+            painter.drawLine(transformedVertices[transformedVertices.size()-2],transformedVertices[transformedVertices.size()-1]);
+        painter.restore();
+    }else if (m_draw_mode==GL_TRIANGLE_FAN){
+        for (int i=1; i<transformedVertices.size()-1; i++)
+        {
+            painter.drawLine(transformedVertices[0],transformedVertices[i]);
+            painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
+            painter.drawLine(transformedVertices[i+1],transformedVertices[0]);
+        }
+        painter.restore();
+    }else if (m_draw_mode==GL_LINE_STRIP)
     {
         for (int i =0; i<transformedVertices.size()-1; i++)
             painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
@@ -80,18 +106,25 @@ void vogleditor_QVertexVisualizer::paintEvent(QPaintEvent *event)
         for (int i =0; i<transformedVertices.size()-1; i=i+2)
             painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
         painter.restore();
+    }else if (m_draw_mode==GL_LINE_LOOP || m_draw_mode==GL_POLYGON)
+    {
+        for (int i =0; i<transformedVertices.size()-1; i++)
+            painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
+        painter.drawLine(transformedVertices[transformedVertices.size()-1],transformedVertices[0]);
+        painter.restore();
     }else if (m_draw_mode==GL_POINTS )
     {
         for (int i =0; i<transformedVertices.size(); i++)
             painter.drawPoint(transformedVertices[i]);
         painter.restore();
-    }else if (m_draw_mode==GL_TRIANGLES){
-        for (int i =0; i<transformedVertices.size()/3; i++)
+    }else if (m_draw_mode==GL_QUADS){
+        for (int i =0; i<transformedVertices.size()/4; i++)
         {
-            int j=i*3;
+            int j=i*4;
             painter.drawLine(transformedVertices[j],transformedVertices[j+1]);
             painter.drawLine(transformedVertices[j+1],transformedVertices[j+2]);
-            painter.drawLine(transformedVertices[j+2],transformedVertices[j]);
+            painter.drawLine(transformedVertices[j+2],transformedVertices[j+3]);
+            painter.drawLine(transformedVertices[j+3],transformedVertices[j]);
         }
         painter.restore();
     }else
@@ -142,6 +175,8 @@ void vogleditor_QVertexVisualizer::showContextMenu(const QPoint &pos)
    modes.append(QPair<GLenum, QString>(GL_TRIANGLE_STRIP_ADJACENCY,"GL_TRIANGLE_STRIP_ADJACENCY"));
    modes.append(QPair<GLenum, QString>(GL_TRIANGLE_STRIP_ADJACENCY,"GL_TRIANGLES_ADJACENCY"));
    modes.append(QPair<GLenum, QString>(GL_PATCHES,"GL_PATCHES"));
+   modes.append(QPair<GLenum, QString>(GL_QUADS,"GL_QUADS"));
+   modes.append(QPair<GLenum, QString>(GL_POLYGON,"GL_POLYGON"));
    QActionGroup drawModeGroup(&drawModeMenu);
    drawModeGroup.setExclusive(true);
    QPair<GLenum, QString> mode;
@@ -153,7 +188,11 @@ void vogleditor_QVertexVisualizer::showContextMenu(const QPoint &pos)
        drawModeMenu.addAction(action);
        action->setCheckable(true);
        //At the moment we only supports these modes:
-       if (!(mode.first==GL_LINES || mode.first==GL_TRIANGLES || mode.first==GL_LINE_STRIP || mode.first==GL_POINTS))
+       if (!(mode.first==GL_LINES || mode.first==GL_TRIANGLES ||
+             mode.first==GL_LINE_STRIP || mode.first==GL_POINTS ||
+             mode.first==GL_LINE_LOOP || mode.first==GL_TRIANGLE_STRIP ||
+             mode.first==GL_TRIANGLE_FAN || mode.first==GL_QUADS ||
+             mode.first==GL_POLYGON))
            action->setEnabled(false);
        if (mode.first==m_draw_mode)
            action->setChecked(true);

--- a/src/vogleditor/vogleditor_qvertexvisualizer.cpp
+++ b/src/vogleditor/vogleditor_qvertexvisualizer.cpp
@@ -1,0 +1,233 @@
+#include <QWidget>
+#include <QtDebug>
+#include <QMatrix4x4>
+#include <QVector2D>
+#include <QMouseEvent>
+#include <QMenu>
+#include <QPainter>
+
+#include "vogleditor_qvertexvisualizer.h"
+
+vogleditor_QVertexVisualizer::vogleditor_QVertexVisualizer(QWidget *parent)
+    : QWidget(parent),
+      m_xRot(0),
+      m_yRot(0),
+      m_zRot(0),
+      m_draw_mode(GL_TRIANGLES)
+{
+    setMinimumSize(144,81);
+    m_projection=new QMatrix4x4;
+}
+
+vogleditor_QVertexVisualizer::~vogleditor_QVertexVisualizer()
+{
+
+}
+
+void vogleditor_QVertexVisualizer::setLabel(QString label)
+{
+    m_label=label;
+    update();
+}
+
+void vogleditor_QVertexVisualizer::setVertices(QVector<QVector3D> vertices)
+{
+    m_vertices=vertices;
+    float maxValue=0;
+    foreach (QVector3D vertex, m_vertices) {
+        maxValue=qMax(maxValue, qAbs(vertex.x()));
+        maxValue=qMax(maxValue, qAbs(vertex.y()));
+        maxValue=qMax(maxValue, qAbs(vertex.z()));
+    }
+    vogleditor_output_message(QString::number(maxValue).toLocal8Bit());
+    m_projection->setToIdentity();
+    m_projection->ortho(-maxValue,maxValue,-maxValue,maxValue,-maxValue,maxValue);
+}
+
+void vogleditor_QVertexVisualizer::paintEvent(QPaintEvent *event)
+{
+    QPainter painter(this);
+    painter.drawText(QRectF(0, 0, width(), height()), Qt::AlignCenter | Qt::AlignBottom , m_label);
+
+    painter.save();
+    painter.scale(height()/2,-height()/2);
+    painter.translate(1.0f*((float)width()/(float)height()),-1);
+    QPen pen = painter.pen();
+    pen.setWidth(0);
+    painter.setPen(pen);
+//    painter.setRenderHint(QPainter::Antialiasing);
+
+    QMatrix4x4 viewMatrix;
+    viewMatrix.setToIdentity();
+    viewMatrix.rotate(m_xRot / 16.0f, 1, 0, 0);
+    viewMatrix.rotate(m_yRot / 16.0f, 0, 1, 0);
+    viewMatrix.rotate(m_zRot / 16.0f, 0, 0, 1);
+
+    QMatrix4x4 VPMatrix = viewMatrix*(*m_projection);
+
+    QVector<QPointF> transformedVertices;
+    foreach (QVector3D vertex, m_vertices) {
+        transformedVertices.push_back((VPMatrix*vertex).toVector2D().toPointF());
+    }
+    //TODO Support more drawing modes.
+    if (m_draw_mode==GL_LINE_STRIP)
+    {
+        for (int i =0; i<transformedVertices.size()-1; i++)
+            painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
+        painter.restore();
+    }else if (m_draw_mode==GL_LINES)
+    {
+        for (int i =0; i<transformedVertices.size()-1; i=i+2)
+            painter.drawLine(transformedVertices[i],transformedVertices[i+1]);
+        painter.restore();
+    }else if (m_draw_mode==GL_POINTS )
+    {
+        for (int i =0; i<transformedVertices.size(); i++)
+            painter.drawPoint(transformedVertices[i]);
+        painter.restore();
+    }else if (m_draw_mode==GL_TRIANGLES){
+        for (int i =0; i<transformedVertices.size()/3; i++)
+        {
+            int j=i*3;
+            painter.drawLine(transformedVertices[j],transformedVertices[j+1]);
+            painter.drawLine(transformedVertices[j+1],transformedVertices[j+2]);
+            painter.drawLine(transformedVertices[j+2],transformedVertices[j]);
+        }
+        painter.restore();
+    }else
+    {
+        painter.restore();
+        painter.drawText(QRectF(0, 0, width(), height()), Qt::AlignCenter | Qt::AlignVCenter , "Draw mode\nnot supported\nby visualizer.");
+    }
+}
+
+void vogleditor_QVertexVisualizer::mousePressEvent(QMouseEvent *event)
+{
+    if (event->buttons() == Qt::RightButton)
+        showContextMenu(event->pos());
+    else if (event->buttons() == Qt::LeftButton)
+        m_lastPos = event->pos();
+}
+
+void vogleditor_QVertexVisualizer::mouseMoveEvent(QMouseEvent *event)
+{
+    if (event->buttons() & Qt::LeftButton) {
+        int dx = event->x() - m_lastPos.x();
+        int dy = event->y() - m_lastPos.y();
+        setXRotation(m_xRot - 8 * dy);
+        setYRotation(m_yRot - 8 * dx);
+        m_lastPos = event->pos();
+   }
+}
+
+void vogleditor_QVertexVisualizer::showContextMenu(const QPoint &pos)
+{
+   QMenu contextMenu(tr("Context Menu"), this);
+
+   QAction popup_action("Show In New Window", this);
+   connect(&popup_action, SIGNAL(triggered()), this, SLOT(ShowInWindow()));
+   contextMenu.addAction(&popup_action);
+
+   QMenu drawModeMenu(tr("Set Draw Mode"), this);
+   QList <QPair <GLenum, QString> > modes;
+   modes.append(QPair<GLenum, QString>(GL_POINTS,"GL_POINTS"));
+   modes.append(QPair<GLenum, QString>(GL_LINE_STRIP,"GL_LINE_STRIP"));
+   modes.append(QPair<GLenum, QString>(GL_LINE_LOOP,"GL_LINE_LOOP"));
+   modes.append(QPair<GLenum, QString>(GL_LINES,"GL_LINES"));
+   modes.append(QPair<GLenum, QString>(GL_LINE_STRIP_ADJACENCY,"GL_LINE_STRIP_ADJACENCY"));
+   modes.append(QPair<GLenum, QString>(GL_LINES_ADJACENCY,"GL_LINES_ADJACENCY"));
+   modes.append(QPair<GLenum, QString>(GL_TRIANGLE_STRIP,"GL_TRIANGLE_STRIP"));
+   modes.append(QPair<GLenum, QString>(GL_TRIANGLE_FAN,"GL_TRIANGLE_FAN"));
+   modes.append(QPair<GLenum, QString>(GL_TRIANGLES,"GL_TRIANGLES"));
+   modes.append(QPair<GLenum, QString>(GL_TRIANGLE_STRIP_ADJACENCY,"GL_TRIANGLE_STRIP_ADJACENCY"));
+   modes.append(QPair<GLenum, QString>(GL_TRIANGLE_STRIP_ADJACENCY,"GL_TRIANGLES_ADJACENCY"));
+   modes.append(QPair<GLenum, QString>(GL_PATCHES,"GL_PATCHES"));
+   QActionGroup drawModeGroup(&drawModeMenu);
+   drawModeGroup.setExclusive(true);
+   QPair<GLenum, QString> mode;
+   foreach (mode, modes) {
+       QAction *action = new QAction(mode.second, &drawModeMenu);
+       drawModeGroup.addAction(action);
+       action->setData(mode.first);
+       connect(action, SIGNAL(triggered()), this, SLOT(DrawModeMenuSelected()));
+       drawModeMenu.addAction(action);
+       action->setCheckable(true);
+       //At the moment we only supports these modes:
+       if (!(mode.first==GL_LINES || mode.first==GL_TRIANGLES || mode.first==GL_LINE_STRIP || mode.first==GL_POINTS))
+           action->setEnabled(false);
+       if (mode.first==m_draw_mode)
+           action->setChecked(true);
+   }
+   contextMenu.addMenu(&drawModeMenu);
+
+   QAction reset_action("Reset roataion", this);
+   connect(&reset_action, SIGNAL(triggered()), this, SLOT(ResetRotation()));
+   contextMenu.addAction(&reset_action);
+
+   contextMenu.exec(mapToGlobal(pos));
+}
+
+void vogleditor_QVertexVisualizer::setDrawMode(GLenum draw_mode)
+{
+    m_draw_mode=draw_mode;
+    update();
+}
+
+void vogleditor_QVertexVisualizer::DrawModeMenuSelected()
+{
+    QAction* senderAction = (QAction*)(sender());
+    int new_mode = senderAction->data().toInt();
+    setDrawMode(new_mode);
+}
+
+void vogleditor_QVertexVisualizer::ResetRotation()
+{
+    m_xRot=0;
+    m_yRot=0;
+    m_zRot=0;
+    update();
+}
+
+void vogleditor_QVertexVisualizer::ShowInWindow()
+{
+    vogleditor_QVertexVisualizer *new_window = new vogleditor_QVertexVisualizer();
+    new_window->setDrawMode(m_draw_mode);
+    new_window->setWindowTitle(m_label);
+    new_window->setVertices(m_vertices);
+    new_window->show();
+}
+
+void vogleditor_QVertexVisualizer::normalizeAngle(int &angle)
+{
+    while (angle < 0)
+        angle += 360 * 16;
+    while (angle > 360 * 16)
+        angle -= 360 * 16;
+}
+
+void vogleditor_QVertexVisualizer::setXRotation(int angle)
+{
+    normalizeAngle(angle);
+    if (angle != m_xRot) {
+        m_xRot = angle;
+        update();
+    }
+}
+
+void vogleditor_QVertexVisualizer::setYRotation(int angle)
+{
+    normalizeAngle(angle);
+    if (angle != m_yRot) {
+        m_yRot = angle;
+        update();
+    }
+}
+
+void vogleditor_QVertexVisualizer::setZRotation(int angle)
+{
+    normalizeAngle(angle);
+    if (angle != m_zRot) {
+        m_zRot = angle;
+        update();
+    }
+}

--- a/src/vogleditor/vogleditor_qvertexvisualizer.h
+++ b/src/vogleditor/vogleditor_qvertexvisualizer.h
@@ -1,0 +1,49 @@
+#ifndef VOGLEDITOR_QVERTEXVISUALIZEREXPLORER_H
+#define VOGLEDITOR_QVERTEXVISUALIZEREXPLORER_H
+
+#include <QWidget>
+#include "vogl_core.h"
+#include "gl_types.h"
+#include "vogleditor_output.h"
+
+#include <QVector>
+#include <QVector3D>
+
+class QMatrix4x4;
+
+class vogleditor_QVertexVisualizer : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit vogleditor_QVertexVisualizer(QWidget *parent = 0);
+    ~vogleditor_QVertexVisualizer();
+    void setLabel(QString label);
+    void setVertices(QVector<QVector3D> vertices);
+    static void normalizeAngle(int &angle);
+protected:
+    void paintEvent ( QPaintEvent * event );
+    void mousePressEvent(QMouseEvent *event);
+    void mouseMoveEvent(QMouseEvent *event);
+private:
+    QString m_label;
+    QVector<QVector3D> m_vertices;
+    QMatrix4x4 *m_projection;
+    int m_xRot;
+    int m_yRot;
+    int m_zRot;
+    QPoint m_lastPos;
+    GLenum m_draw_mode;
+    void setXRotation(int angle);
+    void setYRotation(int angle);
+    void setZRotation(int angle);
+    void showContextMenu(const QPoint &pos);
+public slots:
+    void setDrawMode(GLenum draw_mode);
+    void ShowInWindow();
+    void ResetRotation();
+private slots:
+    void DrawModeMenuSelected();
+};
+
+#endif // VOGLEDITOR_QVERTEXVISUALIZEREXPLORER_H


### PR DESCRIPTION
Added a new widget that displays vertex data graphically in the vertex array explorer tab.
The view angle can be changed by clicking and dragging on the widget.
Right-clicking the widget displays a menu that allows you to change the wire-frame render style, by default it is drawn in a manner that represents the mode in the last selected draw call. 
The menu also has an option to pop-up a separate (larger) window. 
All drawing in this widget is done using QPainter draw calls, no OpenGL is used to ensure it could not break the playback or make improving playback difficult.
![snapshot179](https://cloud.githubusercontent.com/assets/7271935/7137142/08ab17f8-e2af-11e4-94ea-2b61f18b2f12.png)