### PR TITLE
Fix for Issue #209:

### DIFF
--- a/src/vogleditor/vogleditor_qsettings.h
+++ b/src/vogleditor/vogleditor_qsettings.h
@@ -3,6 +3,7 @@
 
 #include "vogl_dynamic_string.h"
 #include "vogl_json.h"
+#include <QObject>
 #include <QStringList>
 #include <QVector>
 


### PR DESCRIPTION
Issue: [vogleditor] Build failure with Qt 5.5

(1) Requires an additional header file QObject to be included;

Build still works with Qt 5.5 and 5.4 (Ubuntu 15.10);

* Issue was solved by @imirkin and @karolherbst *
