### PR TITLE
Fix Linux X11 conflits with Qt 5.9

### DIFF
--- a/src/voglcommon/vogl_gl_replayer.h
+++ b/src/voglcommon/vogl_gl_replayer.h
@@ -1341,7 +1341,7 @@ private:
     int find_attrib_key(const vogl::vector<int> &attrib_list, int key_to_find);
 
     status_t create_context_attribs(
-        vogl_trace_context_ptr_value trace_context, vogl_trace_context_ptr_value trace_share_context, GLReplayContextType replay_share_context, Bool direct,
+        vogl_trace_context_ptr_value trace_context, vogl_trace_context_ptr_value trace_share_context, GLReplayContextType replay_share_context, int direct,
         const int *pTrace_attrib_list, int trace_attrib_list_size, bool expecting_attribs);
 
     status_t process_pending_make_current();

--- a/src/voglcommon/vogl_replay_window.cpp
+++ b/src/voglcommon/vogl_replay_window.cpp
@@ -169,7 +169,7 @@ bool vogl_replay_window::get_actual_dimensions(uint32_t &width, uint32_t &height
     #endif
 }
 
-GLReplayContextType vogl_replay_window::create_context(GLReplayContextType replay_share_context, Bool direct)
+GLReplayContextType vogl_replay_window::create_context(GLReplayContextType replay_share_context, int direct)
 {
     #if (VOGL_PLATFORM_HAS_SDL)
         if (replay_share_context) 
@@ -187,7 +187,7 @@ GLReplayContextType vogl_replay_window::create_context(GLReplayContextType repla
     #endif
 }
 
-GLReplayContextType vogl_replay_window::create_new_context(GLReplayContextType replay_share_context, int render_type, Bool direct)
+GLReplayContextType vogl_replay_window::create_new_context(GLReplayContextType replay_share_context, int render_type, int direct)
 {
     #if (VOGL_PLATFORM_HAS_SDL)
         if (replay_share_context) 
@@ -206,7 +206,7 @@ GLReplayContextType vogl_replay_window::create_new_context(GLReplayContextType r
 }
 
 
-GLReplayContextType vogl_replay_window::create_context_attrib(GLReplayContextType replay_share_context, Bool direct, const int * pAttrib_list)
+GLReplayContextType vogl_replay_window::create_context_attrib(GLReplayContextType replay_share_context, int direct, const int * pAttrib_list)
 {
     #if (VOGL_PLATFORM_HAS_SDL)
         // TODO: This is actually a bit complicated, we need to decode the the attrib list into SDL attribs. 
@@ -245,7 +245,7 @@ void vogl_replay_window::destroy_context(GLReplayContextType context)
     #endif
 }
 
-Bool vogl_replay_window::is_direct(GLReplayContextType replay_context)
+int vogl_replay_window::is_direct(GLReplayContextType replay_context)
 {
     #if (VOGL_PLATFORM_HAS_SDL)
         // We don't have a good way to ask here, so just say yes.
@@ -267,7 +267,7 @@ void vogl_replay_window::swap_buffers()
 }
 
 
-Bool vogl_replay_window::query_version(int *out_major, int *out_minor)
+int vogl_replay_window::query_version(int *out_major, int *out_minor)
 {
     VOGL_ASSERT(out_major != NULL);
     VOGL_ASSERT(out_minor != NULL);

--- a/src/voglcommon/vogl_replay_window.h
+++ b/src/voglcommon/vogl_replay_window.h
@@ -94,13 +94,13 @@ public:
     bool get_actual_dimensions(uint32_t &width, uint32_t &height) const;
 
     // Create a simple context for this window (using glXCreateContext)
-    GLReplayContextType create_context(GLReplayContextType replay_share_context, Bool direct);
+    GLReplayContextType create_context(GLReplayContextType replay_share_context, int direct);
 
     // Create a context using glXCreateNewContext, if available.
-    GLReplayContextType create_new_context(GLReplayContextType replay_share_context, int render_type, Bool direct);
+    GLReplayContextType create_new_context(GLReplayContextType replay_share_context, int render_type, int direct);
 
     // Create a context with CreateContextAttribs on this platform
-    GLReplayContextType create_context_attrib(GLReplayContextType replay_share_context, Bool direct, const int *pAttrib_list);
+    GLReplayContextType create_context_attrib(GLReplayContextType replay_share_context, int direct, const int *pAttrib_list);
 
     // Make the replay context current on this window
     bool make_current(GLReplayContextType context);
@@ -108,9 +108,9 @@ public:
     // Destroy this context, which should be associated with this window.
     void destroy_context(GLReplayContextType context);
 
-    Bool query_version(int *out_major, int *out_minor);
+    int query_version(int *out_major, int *out_minor);
 
-    Bool is_direct(GLReplayContextType replay_context);
+    int is_direct(GLReplayContextType replay_context);
 
     void swap_buffers();
 

--- a/src/vogleditor/fix_x11.h
+++ b/src/vogleditor/fix_x11.h
@@ -1,0 +1,13 @@
+#if defined(PLATFORM_LINUX)
+    #undef Bool
+    #undef CursorShape
+    #undef Expose
+    #undef KeyPress
+    #undef KeyRelease
+    #undef FocusIn
+    #undef FocusOut
+    #undef FontChange
+    #undef None
+    #undef Status
+    #undef Unsorted
+#endif

--- a/src/vogleditor/vogleditor_apicalltreeitem.cpp
+++ b/src/vogleditor/vogleditor_apicalltreeitem.cpp
@@ -32,6 +32,7 @@
 
 #include "vogleditor_frameitem.h"
 #include "vogl_common.h"
+#include "fix_x11.h"
 #include "vogl_trace_file_reader.h"
 #include "vogl_trace_packet.h"
 #include "vogl_trace_stream_types.h"

--- a/src/vogleditor/vogleditor_apicalltreeitem.h
+++ b/src/vogleditor/vogleditor_apicalltreeitem.h
@@ -30,6 +30,7 @@
 #include <QVariant>
 #include "vogl_core.h"
 #include "vogl_common.h"
+#include "fix_x11.h"
 
 class vogleditor_frameItem;
 class vogleditor_groupItem;

--- a/src/vogleditor/vogleditor_qapicalltreemodel.h
+++ b/src/vogleditor/vogleditor_qapicalltreemodel.h
@@ -29,6 +29,7 @@
 #include <QAbstractItemModel>
 #include <QLinkedList>
 #include "vogl_common.h"
+#include "fix_x11.h"
 
 class QVariant;
 class vogleditor_apiCallTreeItem;

--- a/src/vogleditor/vogleditor_qsettings.cpp
+++ b/src/vogleditor/vogleditor_qsettings.cpp
@@ -1,5 +1,6 @@
 #include "vogleditor_qsettings.h"
 #include "vogl_common.h"
+#include "fix_x11.h"
 #include "vogl_file_utils.h"
 
 // declared as extern in header

--- a/src/vogleditor/vogleditor_snapshotitem.h
+++ b/src/vogleditor/vogleditor_snapshotitem.h
@@ -28,6 +28,7 @@
 
 // external classes (could be predeclared)
 #include "vogl_common.h"
+#include "fix_x11.h"
 #include "vogleditor_gl_state_snapshot.h"
 
 // base class for items that might have a snapshot

--- a/src/vogleditor/vogleditor_timelineitem.cpp
+++ b/src/vogleditor/vogleditor_timelineitem.cpp
@@ -27,6 +27,7 @@
 
 #include "vogleditor_timelineitem.h"
 #include "vogl_common.h"
+#include "fix_x11.h"
 
 // Timeline root (fullspan)
 vogleditor_timelineItem::vogleditor_timelineItem(double begin, double end)

--- a/src/vogleditor/vogleditor_tracereplayer.h
+++ b/src/vogleditor/vogleditor_tracereplayer.h
@@ -2,6 +2,7 @@
 #define VOGLEDITOR_TRACEREPLAYER_H
 
 #include "vogl_common.h"
+#include "fix_x11.h"
 #include "vogl_replay_window.h"
 
 class vogl_gl_replayer;


### PR DESCRIPTION
This solves https://github.com/ValveSoftware/vogl/issues/222

X11 header definitions was conflicting with Qt headers, a solution was to undef the conflicting symbols just after including `vogl_common.h` and avoid to use them

Now I am able to built with Qt 5.9 and GCC 7.2 on ArchLinux